### PR TITLE
Update Go client for latest API schema

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,15 +7,15 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: extractions/setup-just@v3
-      - uses: actions/checkout@v5
+      - uses: extractions/setup-just@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
 
       - name: Cache Go install binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-bin-${{ hashFiles('justfile', '**/go.sum') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: extractions/setup-just@v3
+      - uses: extractions/setup-just@v4
 
       - name: Bump version and push tag
         id: tag_version
@@ -21,7 +21,7 @@ jobs:
         with:
           github_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ steps.tag_version.outputs.new_tag }}
 
@@ -31,7 +31,7 @@ jobs:
           cache: true
 
       - name: Cache Go install binaries
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-go-bin-${{ hashFiles('justfile', '**/go.sum') }}
@@ -52,7 +52,7 @@ jobs:
           token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
       - name: Checkout Homebrew tap
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: hotaisle/homebrew-tap
           path: homebrew-tap
@@ -74,7 +74,7 @@ jobs:
           git push origin main
 
       - name: Checkout APT repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           repository: hotaisle/apt-repo
           path: apt-repo

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,9 @@
+# AGENTS.md
+
+- Always follow the instructions in this `AGENTS.md` file.
+- Always use Conventional Commits for commit messages.
+- Never include Codex, Claude, or other AI-assistant branding in branch names, commit messages, PR titles, PR bodies, or other generated labels.
+- Prefer the "don't repeat yourself" (DRY) code that keeps the result clear and maintainable.
+- Test packages should use the external `foo_test` package form unless there is a specific reason to test unexported internals.
+- Run `just test`, `just link`, `just fmt after making code changes and then clean up any issues.
+- Run all `git` commands sequentially and not parallel.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Download the appropriate rpm package from the [Releases page](https://github.com
 
 ### Prerequisites
 
-- Go 1.25 or later
+- Go 1.26.4 or later
 - [Just](https://github.com/casey/just) command runner
 - [act](https://github.com/nektos/act) (optional)
 

--- a/client/models.go
+++ b/client/models.go
@@ -80,10 +80,12 @@ type TeamInvitationRequest struct {
 
 // BalanceInfo contains balance and estimated time until depletion
 type BalanceInfo struct {
-	AvailableBalance    int64      `json:"available_balance"`
-	HourlyRate          int64      `json:"hourly_rate"`
-	EstimatedRunoutTime *time.Time `json:"estimated_runout_time,omitempty"`
-	MinimumBalance      int64      `json:"minimum_balance,omitempty"`
+	AvailableBalance     int64      `json:"available_balance"`
+	HourlyRate           int64      `json:"hourly_rate"`
+	BareMetalServerCount int64      `json:"bare_metal_server_count"`
+	VirtualMachineCount  int64      `json:"virtual_machine_count"`
+	EstimatedRunoutTime  *time.Time `json:"estimated_runout_time,omitempty"`
+	MinimumBalance       int64      `json:"minimum_balance,omitempty"`
 }
 
 // PurchaseTeamCreditsRequest represents a request to purchase credits for a team

--- a/client/models.go
+++ b/client/models.go
@@ -168,7 +168,9 @@ type Disks struct {
 
 // GPUs represents graphics processing unit information
 type GPUs struct {
-	Components
+	Count        uint64 `json:"count"`
+	Manufacturer string `json:"manufacturer,omitempty"`
+	Model        string `json:"model,omitempty"`
 }
 
 // MemoryModules represents memory module information

--- a/cmd/cli/app.go
+++ b/cmd/cli/app.go
@@ -3,13 +3,14 @@ package cli
 import (
 	"context"
 	"fmt"
-	"hotaisle-cli/internal/api"
-	"hotaisle-cli/internal/config"
-	"hotaisle-cli/internal/log"
 	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"hotaisle-cli/internal/api"
+	"hotaisle-cli/internal/config"
+	"hotaisle-cli/internal/log"
 
 	"github.com/urfave/cli/v3"
 )

--- a/cmd/cli/app_test.go
+++ b/cmd/cli/app_test.go
@@ -1,14 +1,15 @@
 package cli
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"hotaisle-cli/internal/config"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"hotaisle-cli/internal/config"
 
 	"github.com/urfave/cli/v3"
 )

--- a/cmd/cli/command_bare_metal_test.go
+++ b/cmd/cli/command_bare_metal_test.go
@@ -2,11 +2,12 @@ package cli
 
 import (
 	"encoding/json"
+	"net/http"
+	"testing"
+
 	"hotaisle-cli/client"
 	"hotaisle-cli/internal/api"
 	"hotaisle-cli/test"
-	"net/http"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cmd/cli/command_config.go
+++ b/cmd/cli/command_config.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"hotaisle-cli/internal/config"
 	"log/slog"
 	"os"
 	"strings"
+
+	"hotaisle-cli/internal/config"
 
 	"github.com/urfave/cli/v3"
 )

--- a/cmd/cli/command_team_test.go
+++ b/cmd/cli/command_team_test.go
@@ -116,8 +116,10 @@ func TestTeamBalanceCommand_Success(t *testing.T) {
 	app, _ := setupTestApp(t)
 
 	mockBalance := &client.BalanceInfo{
-		AvailableBalance: 1000,
-		HourlyRate:       10,
+		AvailableBalance:     1000,
+		HourlyRate:           10,
+		BareMetalServerCount: 2,
+		VirtualMachineCount:  3,
 	}
 
 	mockClient := test.NewMockHTTPClientWithAssertions(t, "/api/teams/test-team/balance/", http.MethodGet, 200, mockBalance)
@@ -135,6 +137,8 @@ func TestTeamBalanceCommand_Success(t *testing.T) {
 	err = json.Unmarshal([]byte(output), &result)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1000), result.AvailableBalance)
+	assert.Equal(t, int64(2), result.BareMetalServerCount)
+	assert.Equal(t, int64(3), result.VirtualMachineCount)
 }
 
 func TestTeamMembersInviteCommand_Success(t *testing.T) {

--- a/cmd/cli/command_team_test.go
+++ b/cmd/cli/command_team_test.go
@@ -2,11 +2,12 @@ package cli
 
 import (
 	"encoding/json"
+	"net/http"
+	"testing"
+
 	"hotaisle-cli/client"
 	"hotaisle-cli/internal/api"
 	"hotaisle-cli/test"
-	"net/http"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cmd/cli/command_test.go
+++ b/cmd/cli/command_test.go
@@ -3,8 +3,9 @@ package cli
 import (
 	"context"
 	"errors"
-	"hotaisle-cli/test"
 	"testing"
+
+	"hotaisle-cli/test"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v3"

--- a/cmd/cli/command_user_test.go
+++ b/cmd/cli/command_user_test.go
@@ -3,13 +3,14 @@ package cli
 import (
 	"context"
 	"encoding/json"
-	"hotaisle-cli/client"
-	"hotaisle-cli/internal/api"
-	"hotaisle-cli/test"
 	"log/slog"
 	"net/http"
 	"testing"
 	"time"
+
+	"hotaisle-cli/client"
+	"hotaisle-cli/internal/api"
+	"hotaisle-cli/test"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/cmd/cli/command_virtual_machine.go
+++ b/cmd/cli/command_virtual_machine.go
@@ -93,10 +93,8 @@ var virtualMachineCommands = commandDef{
 						return fmt.Errorf("invalid gpu-count: %w", err)
 					}
 					req.GPUs = []client.GPUs{{
-						Components: client.Components{
-							Model: gpuModel,
-							Count: gpuCount,
-						},
+						Model: gpuModel,
+						Count: gpuCount,
 					}}
 				}
 

--- a/cmd/cli/command_virtual_machine.go
+++ b/cmd/cli/command_virtual_machine.go
@@ -48,11 +48,11 @@ var virtualMachineCommands = commandDef{
 			Usage: "Provision a new virtual machine.",
 			Flags: []flagDef{
 				{Name: "team", Usage: "Team handle", Required: true},
-				{Name: "cpu-cores", Usage: "Required CPU cores"},
-				{Name: "ram-gb", Usage: "Required RAM in GB"},
-				{Name: "disk-gb", Usage: "Required Disk in GB"},
+				{Name: "gpu-count", Usage: "GPU count", Required: true},
+				{Name: "cpu-cores", Usage: "CPU cores"},
+				{Name: "ram-gb", Usage: "RAM in GB"},
+				{Name: "disk-gb", Usage: "Disk in GB"},
 				{Name: "gpu-model", Usage: "GPU model"},
-				{Name: "gpu-count", Usage: "GPU count"},
 				{Name: "user-data-url", Usage: "URL for cloud-init user data"},
 			},
 			Action: func(app *App, ctx context.Context, cmd *cli.Command) error {
@@ -132,7 +132,7 @@ var virtualMachineCommands = commandDef{
 		},
 		{
 			Name:  "delete",
-			Usage: "Delete a virtual machine and its resources.",
+			Usage: "Delete a virtual machine and its resources. Ends billing.",
 			Flags: []flagDef{
 				{Name: "team", Usage: "Team handle", Required: true},
 				{Name: "vm", Usage: "VM name", Required: true},
@@ -193,7 +193,7 @@ var virtualMachineCommands = commandDef{
 		},
 		{
 			Name:  "stop",
-			Usage: "Forcefully stop a running virtual machine.",
+			Usage: "Forcefully stop a running virtual machine. Continues billing.",
 			Flags: []flagDef{
 				{Name: "team", Usage: "Team handle", Required: true},
 				{Name: "vm", Usage: "VM name", Required: true},

--- a/cmd/cli/command_virtual_machine_test.go
+++ b/cmd/cli/command_virtual_machine_test.go
@@ -3,11 +3,12 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"testing"
+
 	"hotaisle-cli/client"
 	"hotaisle-cli/internal/api"
 	"hotaisle-cli/test"
-	"net/http"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,11 @@
 module hotaisle-cli
 
-go 1.25.5
+go 1.26.4
 
 require (
 	github.com/phsym/console-slog v0.3.1
 	github.com/stretchr/testify v1.11.1
-	github.com/urfave/cli/v3 v3.6.1
+	github.com/urfave/cli/v3 v3.10.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -18,8 +18,8 @@ github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0t
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/urfave/cli/v3 v3.6.1 h1:j8Qq8NyUawj/7rTYdBGrxcH7A/j7/G8Q5LhWEW4G3Mo=
-github.com/urfave/cli/v3 v3.6.1/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
+github.com/urfave/cli/v3 v3.10.0 h1:0aU8yOObVDMkM13Cj4G+zb4P0PdeJMec65f81Ak1ioM=
+github.com/urfave/cli/v3 v3.10.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -2,10 +2,11 @@ package api
 
 import (
 	"context"
-	"hotaisle-cli/client"
-	"hotaisle-cli/test"
 	"net/http"
 	"testing"
+
+	"hotaisle-cli/client"
+	"hotaisle-cli/test"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,11 +1,12 @@
 package config
 
 import (
-	"hotaisle-cli/internal/log"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"hotaisle-cli/internal/log"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/swagger.json
+++ b/swagger.json
@@ -566,12 +566,30 @@
 			"x-go-package": "github.com/hotaisle/hotManager/api/types"
 		},
 		"GPUs": {
-			"allOf": [
-				{
-					"$ref": "#/definitions/Components"
-				}
-			],
 			"description": "GPUs represents graphics processing unit information",
+			"properties": {
+				"count": {
+					"description": "Number of GPUs of this type",
+					"example": 4,
+					"format": "uint64",
+					"type": "integer",
+					"x-go-name": "Count"
+				},
+				"manufacturer": {
+					"description": "GPU manufacturer",
+					"example": "AMD",
+					"type": "string",
+					"x-go-name": "Manufacturer"
+				},
+				"model": {
+					"description": "GPU model",
+					"example": "MI300X",
+					"type": "string",
+					"x-go-name": "Model"
+				}
+			},
+			"required": ["count"],
+			"type": "object",
 			"x-go-package": "github.com/hotaisle/hotManager/api/types"
 		},
 		"GetUserResponse": {

--- a/swagger.json
+++ b/swagger.json
@@ -1,4242 +1,3967 @@
 {
-  "host": "admin.hotaisle.app",
-  "schemes": ["https"],
-  "basePath": "/api/",
-  "consumes": [
-    "application/json"
-  ],
-  "definitions": {
-    "APIKeyTeam": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/Team"
-        },
-        {
-          "properties": {
-            "roles": {
-              "description": "The complete list of roles this API Key has on the team",
-              "example": [
-                "owner",
-                "purchaser",
-                "operator"
-              ],
-              "items": {
-                "enum": [
-                  "owner",
-                  "purchaser",
-                  "operator",
-                  "user"
-                ],
-                "type": "string"
-              },
-              "type": "array",
-              "x-go-name": "Roles",
-              "x-order": "2"
-            }
-          },
-          "required": [
-            "roles"
-          ],
-          "type": "object"
-        }
-      ],
-      "description": "UserAPIKeyTeam represents a team that the API Key has access to",
-      "x-go-name": "UserAPIKeyTeam",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "AvailableBareMetalTypes": {
-      "description": "AvailableBareMetalTypes is how many bare metal servers of a given type are available to be reserved",
-      "properties": {
-        "MinimumReservationMinutes": {
-          "description": "Minimum reservation time in minutes",
-          "example": 480,
-          "format": "int64",
-          "type": "integer"
-        },
-        "OnDemandPrice": {
-          "description": "Price per hour for on-demand usage in US Cents",
-          "format": "int64",
-          "type": "integer"
-        },
-        "Quantity": {
-          "description": "Quantity of this server type available for reservation",
-          "example": 4,
-          "format": "int64",
-          "type": "integer"
-        },
-        "Specs": {
-          "$ref": "#/definitions/BareMetalServerSpecs"
-        }
-      },
-      "required": [
-        "Quantity",
-        "MinimumReservationMinutes"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "AvailableVirtualMachineTypes": {
-      "description": "AvailableVirtualTypes is how many virtual machines of a given type are available to be deployed",
-      "properties": {
-        "MinimumReservationMinutes": {
-          "description": "Minimum reservation time in minutes",
-          "example": 30,
-          "format": "int64",
-          "type": "integer"
-        },
-        "OnDemandPrice": {
-          "description": "Price per hour for on-demand usage in US Cents",
-          "format": "int64",
-          "type": "integer"
-        },
-        "Quantity": {
-          "description": "Quantity of this VM Type available for deployment",
-          "example": 4,
-          "format": "int64",
-          "type": "integer"
-        },
-        "Specs": {
-          "$ref": "#/definitions/VirtualMachineSpecs"
-        }
-      },
-      "required": [
-        "Quantity",
-        "MinimumReservationMinutes"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "BalanceInfo": {
-      "description": "BalanceInfo contains balance and estimated time until depletion",
-      "properties": {
-        "available_balance": {
-          "description": "Available balance in US cents (100 = $1.00)",
-          "example": 50000,
-          "format": "int64",
-          "type": "integer",
-          "x-go-name": "AvailableBalance"
-        },
-        "estimated_runout_time": {
-          "description": "Estimated time when balance will be completely depleted based on current resource usage",
-          "example": "2025-05-20T10:30:00Z",
-          "format": "date-time",
-          "type": "string",
-          "x-go-name": "EstimatedRunoutTime"
-        },
-        "hourly_rate": {
-          "description": "Total hourly cost of all active resources in US cents (100 = $1.00/hour)",
-          "example": 1250,
-          "format": "int64",
-          "type": "integer",
-          "x-go-name": "HourlyRate"
-        },
-        "minimum_balance": {
-          "description": "Minimum balance threshold in US cents (100 = $1.00). Only included when non-zero.",
-          "example": 1000,
-          "format": "int64",
-          "type": "integer",
-          "x-go-name": "MinimumBalance"
-        }
-      },
-      "required": [
-        "available_balance",
-        "hourly_rate"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "BareMetalServer": {
-      "description": "BareMetalServer represents a bare metal server",
-      "properties": {
-        "description": {
-          "description": "Server description",
-          "example": "Production database server",
-          "type": "string",
-          "x-go-name": "Description"
-        },
-        "ip_address": {
-          "description": "Server's primary IP address",
-          "example": "192.168.1.100",
-          "type": "string",
-          "x-go-name": "IPAddress"
-        },
-        "manufacturer": {
-          "description": "Server manufacturer",
-          "example": "Dell",
-          "type": "string",
-          "x-go-name": "Manufacturer"
-        },
-        "model": {
-          "description": "Server model",
-          "example": "PowerEdge XE9680",
-          "type": "string",
-          "x-go-name": "Model"
-        },
-        "name": {
-          "description": "Server Name",
-          "example": "server-01",
-          "type": "string",
-          "x-go-name": "Name"
-        },
-        "ssh_access": {
-          "$ref": "#/definitions/ExternalService"
-        },
-        "support_access_enabled": {
-          "description": "Indicates if Hot Aisle Support is permitted to login to this server",
-          "type": "boolean",
-          "x-go-name": "SupportAccessEnabled"
-        }
-      },
-      "required": [
-        "name",
-        "ip_address",
-        "manufacturer",
-        "model"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "BareMetalServerConsoleURL": {
-      "description": "BareMetalServerConsoleURL has a temporary URL that can be used to access a local console",
-      "properties": {
-        "url": {
-          "description": "URL for console access",
-          "type": "string",
-          "x-go-name": "URL"
-        }
-      },
-      "required": [
-        "url"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "BareMetalServerDetails": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/BareMetalServer"
-        },
-        {
-          "$ref": "#/definitions/BareMetalServerSpecs"
-        },
-        {
-          "properties": {
-            "os_status": {
-              "$ref": "#/definitions/BareMetalServerlOSStatus"
-            }
-          },
-          "type": "object"
-        }
-      ],
-      "description": "BareMetalServerDetails represents a bare metal server with detailed hardware specifications",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "BareMetalServerPowerState": {
-      "description": "BareMetalServerPowerState represents the current power status of a server",
-      "properties": {
-        "state": {
-          "description": "The current power state of the server reported by iDrac.\nValues can be \"On\" or \"Off\".",
-          "enum": [
-            "On",
-            "Off"
-          ],
-          "example": "On",
-          "type": "string",
-          "x-go-name": "State"
-        }
-      },
-      "required": [
-        "state"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "BareMetalServerReservation": {
-      "description": "BareMetalServerReservation represents a request to reserve a bare metal server",
-      "properties": {
-        "description": {
-          "description": "Server description",
-          "example": "Production GPU server for machine learning workloads",
-          "type": "string",
-          "x-go-name": "Description"
-        },
-        "specs": {
-          "$ref": "#/definitions/BareMetalServerSpecs"
-        }
-      },
-      "required": [
-        "specs"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "BareMetalServerReservationResponse": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/BareMetalServer"
-        },
-        {
-          "properties": {
-            "cpu_cores": {
-              "description": "Total CPU Cores",
-              "example": 64,
-              "format": "uint64",
-              "type": "integer",
-              "x-go-name": "CPUCores"
-            },
-            "cpus": {
-              "description": "Detailed CPU information",
-              "items": {
-                "$ref": "#/definitions/CPUs"
-              },
-              "type": "array",
-              "x-go-name": "CPUs"
-            },
-            "disk_capacity": {
-              "description": "Total Disk in bytes",
-              "example": 4398046511104,
-              "format": "uint64",
-              "type": "integer",
-              "x-go-name": "DiskCapacity"
-            },
-            "disks": {
-              "description": "Detailed disk information",
-              "items": {
-                "$ref": "#/definitions/Disks"
-              },
-              "type": "array",
-              "x-go-name": "Disks"
-            },
-            "gpus": {
-              "description": "Detailed GPU information if present",
-              "items": {
-                "$ref": "#/definitions/GPUs"
-              },
-              "type": "array",
-              "x-go-name": "GPUs"
-            },
-            "memory_modules": {
-              "description": "Detailed memory module information",
-              "items": {
-                "$ref": "#/definitions/MemoryModules"
-              },
-              "type": "array",
-              "x-go-name": "MemoryModules"
-            },
-            "os_status": {
-              "$ref": "#/definitions/BareMetalServerlOSStatus"
-            },
-            "ram_capacity": {
-              "description": "Total RAM in bytes",
-              "example": 549755813888,
-              "format": "uint64",
-              "type": "integer",
-              "x-go-name": "RAMCapacity"
-            }
-          },
-          "required": [
-            "cpu_cores",
-            "ram_capacity",
-            "disk_capacity"
-          ],
-          "type": "object"
-        }
-      ],
-      "description": "BareMetalServerReservationResponse represents the response after successfully reserving a server",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "BareMetalServerSpecs": {
-      "description": "BareMetalServerSpecs contains the hardware specifications of a server",
-      "properties": {
-        "cpu_cores": {
-          "description": "Total CPU Cores",
-          "example": 64,
-          "format": "uint64",
-          "type": "integer",
-          "x-go-name": "CPUCores"
-        },
-        "cpus": {
-          "description": "Detailed CPU information",
-          "items": {
-            "$ref": "#/definitions/CPUs"
-          },
-          "type": "array",
-          "x-go-name": "CPUs"
-        },
-        "disk_capacity": {
-          "description": "Total Disk in bytes",
-          "example": 4398046511104,
-          "format": "uint64",
-          "type": "integer",
-          "x-go-name": "DiskCapacity"
-        },
-        "disks": {
-          "description": "Detailed disk information",
-          "items": {
-            "$ref": "#/definitions/Disks"
-          },
-          "type": "array",
-          "x-go-name": "Disks"
-        },
-        "gpus": {
-          "description": "Detailed GPU information if present",
-          "items": {
-            "$ref": "#/definitions/GPUs"
-          },
-          "type": "array",
-          "x-go-name": "GPUs"
-        },
-        "memory_modules": {
-          "description": "Detailed memory module information",
-          "items": {
-            "$ref": "#/definitions/MemoryModules"
-          },
-          "type": "array",
-          "x-go-name": "MemoryModules"
-        },
-        "ram_capacity": {
-          "description": "Total RAM in bytes",
-          "example": 549755813888,
-          "format": "uint64",
-          "type": "integer",
-          "x-go-name": "RAMCapacity"
-        }
-      },
-      "required": [
-        "cpu_cores",
-        "ram_capacity",
-        "disk_capacity"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "BareMetalServerUpdate": {
-      "description": "BareMetalServerUpdate represents a bare metal server",
-      "properties": {
-        "description": {
-          "description": "Bare Metal Server description",
-          "type": "string",
-          "x-go-name": "Description"
-        }
-      },
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "BareMetalServerlOSStatus": {
-      "description": "BareMetalServerlOSStatus represents the current state of OS installation on a server",
-      "properties": {
-        "last_imaging_update": {
-          "description": "Last Imaging Update Timestamp\n\nThe date and time when the OS installation status was last updated\nCan be used to track progress and determine if the installation process is active",
-          "example": "2024-12-10T19:20:04.825Z",
-          "format": "date-time",
-          "type": "string",
-          "x-go-name": "LastImagingUpdate"
-        },
-        "os_install_status": {
-          "description": "OS Install Status\n\nThe current stage in the OS installation process.\nProgresses through various states from \"shutting_down\" through \"installing_os\" to \"installed\" or \"failed\" if an error occurs",
-          "enum": [
-            "shutting_down",
-            "ac_reset",
-            "bios_reset",
-            "booting_installer",
-            "installing_os",
-            "finalizing_os",
-            "first_boot",
-            "first_boot_tasks",
-            "installed",
-            "failed"
-          ],
-          "example": "installed",
-          "type": "string",
-          "x-go-name": "OSStatus"
-        },
-        "os_selection": {
-          "description": "OS Selection",
-          "enum": [
-            "ubuntu-2204.5",
-            "ubuntu-2404.1"
-          ],
-          "example": "ubuntu-2204.5",
-          "type": "string",
-          "x-go-name": "OSSelection"
-        }
-      },
-      "required": [
-        "os_selection",
-        "os_install_status",
-        "last_imaging_update"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "CPUs": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/Components"
-        },
-        {
-          "properties": {
-            "cores": {
-              "description": "Cores per processor",
-              "example": 32,
-              "format": "uint64",
-              "type": "integer",
-              "x-go-name": "Cores"
-            },
-            "frequency": {
-              "description": "CPU Frequency in Hertz",
-              "example": 2600000000,
-              "format": "uint64",
-              "type": "integer",
-              "x-go-name": "Frequency"
-            }
-          },
-          "required": [
-            "cores",
-            "frequency"
-          ],
-          "type": "object"
-        }
-      ],
-      "description": "CPUs represents processor information",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "Components": {
-      "description": "Components represents common attributes for hardware components",
-      "properties": {
-        "count": {
-          "description": "Number of components of this type",
-          "example": 4,
-          "format": "uint64",
-          "type": "integer",
-          "x-go-name": "Count"
-        },
-        "manufacturer": {
-          "description": "Component manufacturer",
-          "example": "Intel",
-          "type": "string",
-          "x-go-name": "Manufacturer"
-        },
-        "model": {
-          "description": "Component model",
-          "example": "Xeon Platinum 8470",
-          "type": "string",
-          "x-go-name": "Model"
-        }
-      },
-      "required": [
-        "count",
-        "manufacturer",
-        "model"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "Disks": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/Components"
-        },
-        {
-          "properties": {
-            "capacity": {
-              "description": "Capacity in bytes per disk",
-              "example": 1099511627776,
-              "format": "uint64",
-              "type": "integer",
-              "x-go-name": "Capacity"
-            },
-            "type": {
-              "description": "Disk type, NVMe or SATA-SSD",
-              "enum": [
-                "NVMe",
-                "SATA SSD"
-              ],
-              "example": "NVMe",
-              "type": "string",
-              "x-go-name": "Type"
-            }
-          },
-          "required": [
-            "type",
-            "capacity"
-          ],
-          "type": "object"
-        }
-      ],
-      "description": "Disks represents storage device information",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "EmailCodeRequest": {
-      "description": "EmailCodeRequest contains the email address for requesting a sign-in code",
-      "properties": {
-        "email": {
-          "description": "User's email address",
-          "example": "john.doe@example.com",
-          "type": "string",
-          "x-go-name": "Email"
-        }
-      },
-      "required": [
-        "email"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "ExternalService": {
-      "description": "ExternalService represents information about an externally accessible service",
-      "properties": {
-        "dns_name": {
-          "description": "DNS hostname for the service if available",
-          "example": "server1.example.com",
-          "type": "string",
-          "x-go-name": "DNSName"
-        },
-        "ip_address": {
-          "description": "Public IP address for service access",
-          "example": "203.0.113.10",
-          "type": "string",
-          "x-go-name": "IPAddress"
-        },
-        "port": {
-          "description": "Service port number",
-          "example": 22,
-          "format": "int64",
-          "type": "integer",
-          "x-go-name": "Port"
-        }
-      },
-      "required": [
-        "ip_address",
-        "port"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "GPUs": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/Components"
-        }
-      ],
-      "description": "GPUs represents graphics processing unit information",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "GetUserResponse": {
-      "description": "GetUserResponse represents information about the authenticated user and their teams",
-      "properties": {
-        "teams": {
-          "description": "Teams the user belongs to",
-          "items": {
-            "$ref": "#/definitions/UserTeam"
-          },
-          "type": "array",
-          "x-go-name": "Teams"
-        },
-        "user": {
-          "$ref": "#/definitions/User"
-        }
-      },
-      "required": [
-        "user",
-        "teams"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "MemoryModules": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/Components"
-        },
-        {
-          "properties": {
-            "capacity": {
-              "description": "Capacity in bytes per module",
-              "example": 34359738368,
-              "format": "uint64",
-              "type": "integer",
-              "x-go-name": "Capacity"
-            }
-          },
-          "required": [
-            "capacity"
-          ],
-          "type": "object"
-        }
-      ],
-      "description": "MemoryModules represents memory module information",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "PurchaseTeamCreditsRequest": {
-      "description": "PurchaseTeamCreditsRequest represents a request to purchase credits for a team",
-      "properties": {
-        "cents": {
-          "description": "The amount to purchase in US cents (100 = $1.00)",
-          "example": 10000,
-          "format": "int64",
-          "minimum": 100,
-          "type": "integer",
-          "x-go-name": "Cents"
-        }
-      },
-      "required": [
-        "cents"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "PurchaseTeamCreditsResponse": {
-      "description": "PurchaseTeamCreditsResponse represents the response to a credits purchase request",
-      "properties": {
-        "checkout_url": {
-          "description": "URL to the Stripe Checkout page where the customer can complete payment",
-          "example": "https://checkout.stripe.com/c/pay/cs_test_a1b2c3...",
-          "type": "string",
-          "x-go-name": "CheckoutURL"
-        },
-        "expires_at": {
-          "description": "Expiration time of the checkout session",
-          "example": "2025-05-16T15:30:00Z",
-          "format": "date-time",
-          "type": "string",
-          "x-go-name": "ExpiresAt"
-        }
-      },
-      "required": [
-        "checkout_url",
-        "expires_at"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "RegistrationRequest": {
-      "description": "RegistrationRequest contains the information needed to register a new user",
-      "properties": {
-        "email": {
-          "description": "User's email address",
-          "example": "john.doe@example.com",
-          "type": "string",
-          "x-go-name": "Email"
-        },
-        "name": {
-          "description": "User's full name",
-          "example": "John Doe",
-          "type": "string",
-          "x-go-name": "Name"
-        }
-      },
-      "required": [
-        "name",
-        "email"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "RequestPaymentApprovalRequest": {
-      "description": "RequestPaymentApprovalRequest represents a request for self-service payment approval",
-      "properties": {
-        "message": {
-          "description": "Message from the requesting team explaining what they're building",
-          "example": "We're building a machine learning platform and need GPU resources for training models.",
-          "type": "string",
-          "x-go-name": "Message"
-        }
-      },
-      "required": [
-        "message"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "SSHKey": {
-      "description": "SSHKey represents an SSH public key associated with a user",
-      "properties": {
-        "comment": {
-          "description": "A descriptive comment or label for the key",
-          "example": "user@example.com",
-          "type": "string",
-          "x-go-name": "Comment"
-        },
-        "fingerprint": {
-          "description": "The unique fingerprint of the SSH key",
-          "example": "SHA256:AbCdEfGhIjKlMnOpQrStUvWxYz12345678901234",
-          "type": "string",
-          "x-go-name": "Fingerprint"
-        },
-        "public_key": {
-          "description": "The base64-encoded public key portion",
-          "example": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC...",
-          "type": "string",
-          "x-go-name": "PublicKey"
-        },
-        "type": {
-          "description": "The type of SSH key (e.g., ssh-rsa, ssh-ed25519)",
-          "example": "ssh-rsa",
-          "type": "string",
-          "x-go-name": "Type"
-        }
-      },
-      "required": [
-        "type",
-        "public_key",
-        "fingerprint"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "SSHKeyRequest": {
-      "description": "SSHKeyRequest represents the data needed to add a new SSH key",
-      "properties": {
-        "authorized_key": {
-          "description": "SSH public key in the authorized key format of \u003ctype\u003e \u003cpublic_key\u003e \u003ccomment\u003e",
-          "example": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC... user@example.com",
-          "type": "string",
-          "x-go-name": "AuthorizedKey"
-        }
-      },
-      "required": [
-        "authorized_key"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "Session": {
-      "description": "Session represents an active session with its associated API key information",
-      "properties": {
-        "api_key_prefix": {
-          "description": "The associated API key prefix, if one exists",
-          "example": "b2c3d4e5f6g7h8i9j0k1l2m3n4",
-          "type": "string",
-          "x-go-name": "APIKeyPrefix"
-        },
-        "created": {
-          "description": "When this session was created",
-          "example": "2025-04-10T14:30:00Z",
-          "format": "date-time",
-          "type": "string",
-          "x-go-name": "Created"
-        },
-        "expires_at": {
-          "description": "When this session will expire",
-          "example": "2025-04-17T14:30:00Z",
-          "format": "date-time",
-          "type": "string",
-          "x-go-name": "ExpiresAt"
-        },
-        "prefix": {
-          "description": "The unique prefix identifier for this session",
-          "example": "a1b2c3d4e5f6g7h8i9j0k1l2m3",
-          "type": "string",
-          "x-go-name": "Prefix"
-        }
-      },
-      "required": [
-        "prefix",
-        "expires_at",
-        "created"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "Team": {
-      "description": "Team represents a team",
-      "properties": {
-        "description": {
-          "description": "Team description",
-          "type": "string",
-          "x-go-name": "Description",
-          "x-order": "2"
-        },
-        "handle": {
-          "description": "Team's unique identifier handle",
-          "example": "acme-corporation",
-          "type": "string",
-          "x-go-name": "Handle",
-          "x-order": "0"
-        },
-        "maximum_bare_metal_servers": {
-          "description": "Maximum number of bare metal servers this team can create",
-          "example": 5,
-          "format": "int64",
-          "type": "integer",
-          "x-go-name": "MaximumBareMetalServers",
-          "x-order": "5"
-        },
-        "maximum_virtual_machines": {
-          "description": "Maximum number of virtual machines this team can create",
-          "example": 10,
-          "format": "int64",
-          "type": "integer",
-          "x-go-name": "MaximumVirtualMachines",
-          "x-order": "4"
-        },
-        "name": {
-          "description": "Team's display name",
-          "example": "Acme Corporation",
-          "type": "string",
-          "x-go-name": "Name",
-          "x-order": "1"
-        }
-      },
-      "required": [
-        "handle",
-        "name"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "TeamInvitationRequest": {
-      "description": "TeamInvitationRequest contains the information needed to invite a user to a team",
-      "properties": {
-        "email": {
-          "description": "Invitee's email address",
-          "example": "john.doe@example.com",
-          "maxLength": 254,
-          "type": "string",
-          "x-go-name": "Email"
-        },
-        "name": {
-          "description": "Invitee's full name",
-          "example": "John Doe",
-          "maxLength": 100,
-          "type": "string",
-          "x-go-name": "Name"
-        },
-        "roles": {
-          "description": "Roles to assign to the invitee",
-          "example": [
-            "operator",
-            "user"
-          ],
-          "items": {
-            "enum": [
-              "owner",
-              "purchaser",
-              "operator",
-              "user"
-            ],
-            "type": "string"
-          },
-          "type": "array",
-          "x-go-name": "Roles"
-        }
-      },
-      "required": [
-        "name",
-        "email",
-        "roles"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "TeamMember": {
-      "description": "TeamMember represents a team member or pending invitation",
-      "properties": {
-        "created": {
-          "description": "When the user account was created",
-          "example": "2025-04-10T14:30:00Z",
-          "format": "date-time",
-          "type": "string",
-          "x-go-name": "Created"
-        },
-        "email": {
-          "description": "User's email address",
-          "example": "john.doe@example.com",
-          "type": "string",
-          "x-go-name": "Email"
-        },
-        "invitation": {
-          "description": "This team membership is a invite that has not yet been accepted",
-          "example": true,
-          "type": "boolean",
-          "x-go-name": "Invitation"
-        },
-        "name": {
-          "description": "User's full name",
-          "example": "John Doe",
-          "type": "string",
-          "x-go-name": "Name"
-        },
-        "roles": {
-          "description": "The complete list of roles this user has on the team",
-          "example": [
-            "owner",
-            "purchaser",
-            "operator"
-          ],
-          "items": {
-            "enum": [
-              "owner",
-              "purchaser",
-              "operator",
-              "user"
-            ],
-            "type": "string"
-          },
-          "type": "array",
-          "x-go-name": "Roles"
-        }
-      },
-      "required": [
-        "name",
-        "email",
-        "created",
-        "roles"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "TeamMemberUpdate": {
-      "description": "TeamMemberUpdate represents the data needed to update a team member's roles",
-      "properties": {
-        "roles": {
-          "description": "Updated roles for the team member",
-          "example": [
-            "operator",
-            "user"
-          ],
-          "items": {
-            "enum": [
-              "owner",
-              "purchaser",
-              "operator",
-              "user"
-            ],
-            "type": "string"
-          },
-          "type": "array",
-          "x-go-name": "Roles"
-        }
-      },
-      "required": [
-        "roles"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "TeamUpdate": {
-      "description": "TeamUpdate represents a team",
-      "properties": {
-        "description": {
-          "description": "Team description",
-          "type": "string",
-          "x-go-name": "Description",
-          "x-order": "2"
-        },
-        "handle": {
-          "description": "Team's unique identifier handle",
-          "example": "acme-corporation",
-          "type": "string",
-          "x-go-name": "Handle",
-          "x-order": "0"
-        },
-        "name": {
-          "description": "Team's display name",
-          "example": "Acme Corporation",
-          "type": "string",
-          "x-go-name": "Name",
-          "x-order": "1"
-        }
-      },
-      "required": [
-        "handle",
-        "name"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "User": {
-      "description": "User represents a registered user in the system",
-      "properties": {
-        "created": {
-          "description": "When the user account was created",
-          "example": "2025-04-10T14:30:00Z",
-          "format": "date-time",
-          "type": "string",
-          "x-go-name": "Created"
-        },
-        "email": {
-          "description": "User's email address",
-          "example": "john.doe@example.com",
-          "type": "string",
-          "x-go-name": "Email"
-        },
-        "name": {
-          "description": "User's full name",
-          "example": "John Doe",
-          "type": "string",
-          "x-go-name": "Name"
-        }
-      },
-      "required": [
-        "name",
-        "email",
-        "created"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "UserAPIKey": {
-      "description": "UserAPIKey represents a user's API key",
-      "properties": {
-        "label": {
-          "description": "A descriptive label for the API key",
-          "example": "Development key",
-          "type": "string",
-          "x-go-name": "Label",
-          "x-order": "2"
-        },
-        "prefix": {
-          "description": "The unique prefix of this API key (used for identification)",
-          "example": "6ddfaa4539b4c7e046fe4b94",
-          "type": "string",
-          "x-go-name": "Prefix",
-          "x-order": "0"
-        },
-        "teams": {
-          "description": "Teams that this API key has access to and the roles on each team",
-          "items": {
-            "$ref": "#/definitions/APIKeyTeam"
-          },
-          "type": "array",
-          "x-go-name": "Teams",
-          "x-order": "4"
-        },
-        "user_role": {
-          "description": "The role this API Key has on the user\nKeys with a user role of 'owner' can modify the user, including changing name, leaving or accepting invites to teams, and creating api keys",
-          "enum": [
-            "owner",
-            "user"
-          ],
-          "example": "owner",
-          "type": "string",
-          "x-go-name": "UserRole",
-          "x-order": "3"
-        }
-      },
-      "required": [
-        "user_role"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "UserAPIKeyRequest": {
-      "description": "UserAPIKeyRequest represents the data needed to create or update an API key",
-      "properties": {
-        "label": {
-          "description": "A descriptive label for the API key",
-          "example": "Development key",
-          "type": "string",
-          "x-go-name": "Label",
-          "x-order": "0"
-        },
-        "teams": {
-          "description": "Teams and their associated permissions for this API key",
-          "items": {
-            "$ref": "#/definitions/UserAPIKeyTeamRoles"
-          },
-          "type": "array",
-          "x-go-name": "Teams",
-          "x-order": "2"
-        },
-        "user_role": {
-          "description": "The role this API key has on the user",
-          "enum": [
-            "owner",
-            "user"
-          ],
-          "example": "user",
-          "type": "string",
-          "x-go-name": "UserRole",
-          "x-order": "1"
-        }
-      },
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "UserAPIKeyTeamRoles": {
-      "description": "UserAPIKeyTeamRoles defines the permissions for an API key on a specific team",
-      "properties": {
-        "roles": {
-          "description": "The roles assigned to this API key for the team wtf man",
-          "example": [
-            "operator",
-            "user"
-          ],
-          "items": {
-            "enum": [
-              "owner",
-              "purchaser",
-              "operator",
-              "user"
-            ],
-            "type": "string"
-          },
-          "type": "array",
-          "x-go-name": "Roles"
-        },
-        "team": {
-          "description": "Team slug identifier",
-          "example": "hotaisle-development",
-          "type": "string",
-          "x-go-name": "Team"
-        }
-      },
-      "required": [
-        "team",
-        "roles"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "UserAPIKeyWithToken": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/UserAPIKey"
-        },
-        {
-          "properties": {
-            "token": {
-              "description": "The full token value. This is the only time the full token will be returned, as it is not stored plaintext on the server and cannot be recovered.",
-              "example": "6ddfaa4539b4c7e046fe4b94.ee7003caf1bca1c01bb37b7a870af156d29bfdd5d86113eef99e2f476f91659c",
-              "type": "string",
-              "x-go-name": "Token"
-            }
-          },
-          "type": "object"
-        }
-      ],
-      "description": "UserAPIKeyWithToken represents an API key with its full token value\nOnly returned when creating a new API key",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "UserEmailCodeResponse": {
-      "description": "UserEmailCodeResponse contains information about a sign-in code request",
-      "properties": {
-        "code_expires": {
-          "description": "When the sign-in code expires",
-          "example": "2025-04-10T15:30:00Z",
-          "format": "date-time",
-          "type": "string",
-          "x-go-name": "CodeExpires"
-        },
-        "email": {
-          "description": "User's email address",
-          "example": "john.doe@example.com",
-          "type": "string",
-          "x-go-name": "Email"
-        }
-      },
-      "required": [
-        "email",
-        "code_expires"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "UserRegistrationResponse": {
-      "description": "UserRegistrationResponse contains information about a registration attempt",
-      "properties": {
-        "code_expires": {
-          "description": "When the sign-in code expires",
-          "example": "2025-04-10T15:30:00Z",
-          "format": "date-time",
-          "type": "string",
-          "x-go-name": "CodeExpires"
-        },
-        "email": {
-          "description": "User's email address",
-          "example": "john.doe@example.com",
-          "type": "string",
-          "x-go-name": "Email"
-        },
-        "name": {
-          "description": "User's full name",
-          "example": "John Doe",
-          "type": "string",
-          "x-go-name": "Name"
-        }
-      },
-      "required": [
-        "name",
-        "email",
-        "code_expires"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "UserTeam": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/Team"
-        },
-        {
-          "properties": {
-            "effective_roles": {
-              "description": "The list of effective roles that this authenticated request has, based on API Key restrictions",
-              "example": [
-                "operator",
-                "user"
-              ],
-              "items": {
-                "enum": [
-                  "owner",
-                  "purchaser",
-                  "operator",
-                  "user"
-                ],
-                "type": "string"
-              },
-              "type": "array",
-              "x-go-name": "EffectiveRoles",
-              "x-order": "4"
-            },
-            "invitation": {
-              "description": "This team membership is a invite that has not yet been accepted",
-              "example": true,
-              "type": "boolean",
-              "x-go-name": "Invitation",
-              "x-order": "5"
-            },
-            "roles": {
-              "description": "The complete list of roles this user has on the team",
-              "example": [
-                "owner",
-                "purchaser",
-                "operator"
-              ],
-              "items": {
-                "enum": [
-                  "owner",
-                  "purchaser",
-                  "operator",
-                  "user"
-                ],
-                "type": "string"
-              },
-              "type": "array",
-              "x-go-name": "Roles",
-              "x-order": "3"
-            }
-          },
-          "required": [
-            "roles",
-            "effective_roles"
-          ],
-          "type": "object"
-        }
-      ],
-      "description": "UserTeam represents a team that the user belongs to",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "UserTeamDetails": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/UserTeamWithMembers"
-        },
-        {
-          "properties": {
-            "bare_metal_servers": {
-              "description": "Bare metal servers",
-              "items": {
-                "$ref": "#/definitions/BareMetalServer"
-              },
-              "type": "array",
-              "x-go-name": "BareMetalServers",
-              "x-order": "7"
-            },
-            "virtual_machines": {
-              "description": "Virtual Machines",
-              "items": {
-                "$ref": "#/definitions/VirtualMachine"
-              },
-              "type": "array",
-              "x-go-name": "VirtualMachines",
-              "x-order": "8"
-            }
-          },
-          "type": "object"
-        }
-      ],
-      "description": "UserTeamWithMembers represents a team with detailed information including members and resources",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "UserTeamWithMembers": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/UserTeam"
-        },
-        {
-          "properties": {
-            "members": {
-              "description": "Team members",
-              "items": {
-                "$ref": "#/definitions/TeamMember"
-              },
-              "type": "array",
-              "x-go-name": "Members",
-              "x-order": "6"
-            }
-          },
-          "type": "object"
-        }
-      ],
-      "description": "UserTeamWithMembers represents a team with detailed member information",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "UserUpdate": {
-      "description": "UserUpdate represents the updateable fields for a user",
-      "properties": {
-        "name": {
-          "description": "User's full name",
-          "example": "Jane Smith",
-          "type": "string",
-          "x-go-name": "Name"
-        }
-      },
-      "required": [
-        "name"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "VMProvisionRequest": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/VirtualMachineSpecs"
-        },
-        {
-          "properties": {
-            "user_data_url": {
-              "description": "Optional URL to custom cloud-init user-data\nWhen provided, the VM will be provisioned with this user-data applied\nNote: This will significantly increase provisioning time as the VM will be rebuilt",
-              "example": "https://example.com/my-user-data.yaml",
-              "type": "string",
-              "x-go-name": "UserDataURL"
-            }
-          },
-          "type": "object"
-        }
-      ],
-      "description": "VMProvisionRequest represents a request to provision a virtual machine",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "VMResetRequest": {
-      "description": "VMResetRequest represents a request to reset/rebuild a virtual machine",
-      "properties": {
-        "user_data_url": {
-          "description": "Optional URL to custom cloud-init user-data\nWhen provided, the VM will be rebuilt with this user-data applied",
-          "example": "https://example.com/my-user-data.yaml",
-          "type": "string",
-          "x-go-name": "UserDataURL"
-        }
-      },
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "VirtualMachine": {
-      "description": "VirtualMachine represents a virtual machine instance",
-      "properties": {
-        "description": {
-          "description": "VM description",
-          "example": "Production web server",
-          "type": "string",
-          "x-go-name": "Description"
-        },
-        "ip_address": {
-          "description": "VM's primary IP address",
-          "example": "192.168.1.200",
-          "type": "string",
-          "x-go-name": "IPAddress"
-        },
-        "name": {
-          "description": "VM Name",
-          "example": "vm-01",
-          "type": "string",
-          "x-go-name": "Name"
-        },
-        "ssh_access": {
-          "$ref": "#/definitions/ExternalService"
-        }
-      },
-      "required": [
-        "name",
-        "ip_address"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "VirtualMachineDetails": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/VirtualMachine"
-        },
-        {
-          "$ref": "#/definitions/VirtualMachineSpecs"
-        }
-      ],
-      "description": "VirtualMachineDetails represents a virtual machine with detailed specifications",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "VirtualMachineSpecs": {
-      "description": "VirtualMachineSpecs contains the specifications of a virtual machine",
-      "properties": {
-        "cpu_cores": {
-          "description": "Total CPU Cores",
-          "example": 8,
-          "format": "uint64",
-          "type": "integer",
-          "x-go-name": "CPUCores"
-        },
-        "cpus": {
-          "$ref": "#/definitions/CPUs"
-        },
-        "disk_capacity": {
-          "description": "Total Disk in bytes",
-          "example": 107374182400,
-          "format": "uint64",
-          "type": "integer",
-          "x-go-name": "DiskCapacity"
-        },
-        "gpus": {
-          "description": "GPU information if any GPUs are assigned",
-          "items": {
-            "$ref": "#/definitions/GPUs"
-          },
-          "type": "array",
-          "x-go-name": "GPUs"
-        },
-        "ram_capacity": {
-          "description": "Total RAM in bytes",
-          "example": 34359738368,
-          "format": "uint64",
-          "type": "integer",
-          "x-go-name": "RAMCapacity"
-        }
-      },
-      "required": [
-        "cpu_cores",
-        "ram_capacity",
-        "disk_capacity"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "VirtualMachineState": {
-      "description": "VirtualMachineState represents the current state of a virtual machine",
-      "properties": {
-        "host": {
-          "description": "The host where the VM is running",
-          "example": "vm-host-01",
-          "type": "string",
-          "x-go-name": "Host"
-        },
-        "state": {
-          "description": "The current state of the virtual machine.\nValues can include \"running\", \"shut off\", \"paused\", etc.",
-          "example": "running",
-          "type": "string",
-          "x-go-name": "State"
-        }
-      },
-      "required": [
-        "state",
-        "host"
-      ],
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    },
-    "VirtualMachineUpdate": {
-      "description": "VirtualMachineUpdate represents a bare metal server",
-      "properties": {
-        "description": {
-          "description": "Virtual Machine description",
-          "type": "string",
-          "x-go-name": "Description"
-        }
-      },
-      "type": "object",
-      "x-go-package": "github.com/hotaisle/hotManager/api/types"
-    }
-  },
-  "info": {
-    "description": "Hot Aisle API\n",
-    "title": "hotaisle",
-    "version": "1.0.0"
-  },
-  "paths": {
-    "/teams/": {
-      "get": {
-        "description": "Returns information about the teams the user belongs to, including roles.\n\n---\n\nRequires team role: any (only returns teams for which this API key has a role)",
-        "operationId": "getUserTeamsReq",
-        "responses": {
-          "200": {
-            "description": "User information with teams",
-            "schema": {
-              "items": {
-                "$ref": "#/definitions/UserTeam"
-              },
-              "type": "array"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Get user team membership",
-        "tags": [
-          "teams"
-        ],
-        "x-requires-permissions": "team role: any (only returns teams for which this API key has a role)"
-      },
-      "post": {
-        "description": "Creates a new team with the authenticated user as the owner.\n\n\n---\n\nRequires user role: owner",
-        "operationId": "createTeamReq",
-        "parameters": [
-          {
-            "in": "body",
-            "name": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/Team"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Team created successfully",
-            "schema": {
-              "$ref": "#/definitions/UserTeamWithMembers"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Create a new team",
-        "tags": [
-          "teams"
-        ],
-        "x-requires-permissions": "user role: owner"
-      }
-    },
-    "/teams/invitations/": {
-      "get": {
-        "description": "Returns information about the team invitations that are pending for the user.\n\n---\n\nRequires user role: any",
-        "operationId": "getUserTeamsInvitationsReq",
-        "responses": {
-          "200": {
-            "description": "List of pending team invitations",
-            "schema": {
-              "items": {
-                "$ref": "#/definitions/UserTeam"
-              },
-              "type": "array"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Get user pending team invitations",
-        "tags": [
-          "teams"
-        ],
-        "x-requires-permissions": "user role: any"
-      }
-    },
-    "/teams/{team}/": {
-      "get": {
-        "description": "Returns detailed information about a specific team the user belongs to.\n\n---\n\nRequires team role: any",
-        "operationId": "getUserTeamDetailReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Team details",
-            "schema": {
-              "$ref": "#/definitions/UserTeamDetails"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Get specific team details",
-        "tags": [
-          "teams"
-        ],
-        "x-requires-permissions": "team role: any"
-      },
-      "patch": {
-        "description": "Updates a team's details.\n\n---\n\nRequires team role: owner",
-        "operationId": "updateTeamReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/TeamUpdate"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Team updated successfully",
-            "schema": {
-              "$ref": "#/definitions/UserTeamWithMembers"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Update a team's information",
-        "tags": [
-          "teams"
-        ],
-        "x-requires-permissions": "team role: owner"
-      }
-    },
-    "/teams/{team}/accept-invitation/": {
-      "post": {
-        "description": "Accept a pending invitation to join a team.\n\n---\n\nRequires user role: owner",
-        "operationId": "acceptTeamInvitationReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Invitation accepted, returns updated team details",
-            "schema": {
-              "$ref": "#/definitions/UserTeamWithMembers"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Accept team invitation",
-        "tags": [
-          "teams"
-        ],
-        "x-requires-permissions": "user role: owner"
-      }
-    },
-    "/teams/{team}/balance/": {
-      "get": {
-        "description": "Returns the current available balance, estimated runout time, and hourly rate for all active resources in the team.\n\n---\n\nRequires team role: any",
-        "operationId": "getTeamBalanceReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Team balance information",
-            "schema": {
-              "$ref": "#/definitions/BalanceInfo"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Get team balance information",
-        "tags": [
-          "teams"
-        ],
-        "x-requires-permissions": "team role: any"
-      }
-    },
-    "/teams/{team}/bare_metal/": {
-      "get": {
-        "description": "Returns a list of bare metal servers associated with the team.\n\n---\n\nRequires team role: any",
-        "operationId": "getBaremetalServersReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "List of bare metal servers with detailed specifications",
-            "schema": {
-              "items": {
-                "$ref": "#/definitions/BareMetalServerDetails"
-              },
-              "type": "array"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Get bare metal servers",
-        "tags": [
-          "bare_metal"
-        ],
-        "x-requires-permissions": "team role: any"
-      },
-      "post": {
-        "description": "Reserves a bare metal server for the team, including validation of tenant limits and balance, and submits 8-hour minimum usage to Stripe.\n\n---\n\nRequires team role: operator",
-        "operationId": "reserveBaremetalServerReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/BareMetalServerReservation"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "Server reserved successfully",
-            "schema": {
-              "$ref": "#/definitions/BareMetalServerReservationResponse"
-            }
-          },
-          "400": {
-            "description": "Bad request - invalid specifications or insufficient resources"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "402": {
-            "description": "Payment required - insufficient balance"
-          },
-          "403": {
-            "description": "Forbidden - tenant limit exceeded or insufficient permissions"
-          },
-          "404": {
-            "description": "Not found - no available servers matching specifications"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Reserve a bare metal server",
-        "tags": [
-          "bare_metal"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/teams/{team}/bare_metal/available/": {
-      "get": {
-        "description": "Returns a list of available bare metal server types that can be reserved, including pricing information.\n\n---\n\nRequires team role: any",
-        "operationId": "getAvailableBaremetalServersReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "List of available bare metal server types with specifications and pricing",
-            "schema": {
-              "items": {
-                "$ref": "#/definitions/AvailableBareMetalTypes"
-              },
-              "type": "array"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Get available bare metal server types",
-        "tags": [
-          "bare_metal"
-        ],
-        "x-requires-permissions": "team role: any"
-      }
-    },
-    "/teams/{team}/bare_metal/{server}/": {
-      "delete": {
-        "description": "Releases a bare metal server back to the available pool. Enforces 8-hour minimum usage by checking the Stripe last submission time.\n\n---\n\nRequires team role: operator",
-        "operationId": "deleteBaremetalServerReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Server name",
-            "in": "path",
-            "name": "server",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Server released successfully"
-          },
-          "400": {
-            "description": "Bad request - server cannot be released due to minimum usage requirement"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden - insufficient permissions"
-          },
-          "404": {
-            "description": "Not found - server not found or not assigned to team"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Release a bare metal server",
-        "tags": [
-          "bare_metal"
-        ],
-        "x-requires-permissions": "team role: operator"
-      },
-      "get": {
-        "description": "Returns detailed information about a specific bare metal server.\n\n---\n\nRequires team role: any",
-        "operationId": "getBaremetalServerReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Server name",
-            "in": "path",
-            "name": "server",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Detailed server specifications",
-            "schema": {
-              "$ref": "#/definitions/BareMetalServerDetails"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Get bare metal server details",
-        "tags": [
-          "bare_metal"
-        ],
-        "x-requires-permissions": "team role: any"
-      },
-      "patch": {
-        "description": "Updates a bare metal server's description.\n\n---\n\nRequires team role: operator",
-        "operationId": "updateBaremetalServerReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Server name",
-            "in": "path",
-            "name": "server",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/BareMetalServerUpdate"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Server updated successfully"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Update a bare metal server",
-        "tags": [
-          "bare_metal"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/teams/{team}/bare_metal/{server}/console/": {
-      "post": {
-        "description": "Returns a one time use URL for local console access\n\n---\n\nRequires team role: operator",
-        "operationId": "getBaremetalConsoleReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Server name",
-            "in": "path",
-            "name": "server",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Current power state",
-            "schema": {
-              "$ref": "#/definitions/BareMetalServerConsoleURL"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Generate URL for bare metal console access",
-        "tags": [
-          "bare_metal"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/teams/{team}/bare_metal/{server}/power/": {
-      "get": {
-        "description": "Returns the current power state of the server.\n\n---\n\nRequires team role: any",
-        "operationId": "getServerPowerReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Server name",
-            "in": "path",
-            "name": "server",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Current power state",
-            "schema": {
-              "$ref": "#/definitions/BareMetalServerPowerState"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Get server power state",
-        "tags": [
-          "bare_metal"
-        ],
-        "x-requires-permissions": "team role: any"
-      }
-    },
-    "/teams/{team}/bare_metal/{server}/power/ac_reset/": {
-      "post": {
-        "description": "Performs a complete AC reset of the server. The server must already be in the off state for this to succeed. BMC will also reset during an AC reset, so getting the power state or any other BMC operations will fail for several minutes while this is in progress.\n\n\n---\n\nRequires team role: operator",
-        "operationId": "serverACResetReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Server name",
-            "in": "path",
-            "name": "server",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "AC reset request successful"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Perform AC power reset",
-        "tags": [
-          "bare_metal"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/teams/{team}/bare_metal/{server}/power/cold_reboot/": {
-      "post": {
-        "description": "Turns off and then reboots the system.\n\n---\n\nRequires team role: operator",
-        "operationId": "serverColdRebootReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Server name",
-            "in": "path",
-            "name": "server",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Cold reboot request successful"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Cold reboot the server",
-        "tags": [
-          "bare_metal"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/teams/{team}/bare_metal/{server}/power/force_shutdown/": {
-      "post": {
-        "description": "Immediately powers off the server without a clean shutdown. May cause data loss.\n\n---\n\nRequires team role: operator",
-        "operationId": "serverForceShutdownReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Server name",
-            "in": "path",
-            "name": "server",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Force shutdown request successful"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Force shut down the server",
-        "tags": [
-          "bare_metal"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/teams/{team}/bare_metal/{server}/power/graceful_shutdown/": {
-      "post": {
-        "description": "Sends an ACPI signal to the OS to initiate a clean shutdown.\n\n---\n\nRequires team role: operator",
-        "operationId": "serverGracefulShutdownReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Server name",
-            "in": "path",
-            "name": "server",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Graceful shutdown request successful"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Gracefully shut down the server",
-        "tags": [
-          "bare_metal"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/teams/{team}/bare_metal/{server}/power/power_on/": {
-      "post": {
-        "description": "Turns on the server if it is currently off.\n\n---\n\nRequires team role: operator",
-        "operationId": "serverPowerOnReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Server name",
-            "in": "path",
-            "name": "server",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Power on request successful"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Power on the server",
-        "tags": [
-          "bare_metal"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/teams/{team}/bare_metal/{server}/power/warm_reboot/": {
-      "post": {
-        "description": "Reboots the system without turning the power off completely.\n\n---\n\nRequires team role: operator",
-        "operationId": "serverWarmRebootReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Server name",
-            "in": "path",
-            "name": "server",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Warm reboot request successful"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Warm reboot the server",
-        "tags": [
-          "bare_metal"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/teams/{team}/bare_metal/{server}/reinstall/": {
-      "post": {
-        "description": "Resets BIOS settings, wipes all disks, and reinstalls the operating system. The reinstall process goes through several stages which can be monitored via the server details endpoint.\n1. A graceful shutdown of the server will be triggered and the status will be updated to `shutting_down`. If the server takes more than 5 minutes to shut down, a force shutdown will occur.\n2. The server will perform a full ac reset and put the server in the `ac_reset` state. This will take several minutes.\n3. When the server comes back, a reset of bios settings will be triggred and the server will be in `bios_reset` state. This will take several minutes.\n4. After the bios reset is complete, the server will boot into the installer environment and will be in the `booting_installer` state.\n5. When the installation starts the server will be in the `installing_os` state.\n6. Once the base install is complete, the server will install additional packges and will be in the `finalizing_os` state.\n7. When it completes these tasks and reboots from the installer environment the server will be in the `first_boot` state.\n8. Upon first boot, some final taks will run and the server will be in the `first_boot_tasks` state.\nIf everything completes successfully the server will be in the `installed` state.\nIf any action fails, the server will be in the `failed` state.\nThe `last_imaging_update` will indicate the timestamp of the last update to the install progress.\n\n\n---\n\nRequires team role: operator",
-        "operationId": "serverReinstallReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Server name",
-            "in": "path",
-            "name": "server",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Reinstall process initiated successfully",
-            "schema": {
-              "$ref": "#/definitions/BareMetalServerDetails"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Reinstall server OS",
-        "tags": [
-          "bare_metal"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/teams/{team}/bare_metal/{server}/support_access_enable/": {
-      "delete": {
-        "description": "Revokes Hot Aisle support staff access to this server.\n\n---\n\nRequires team role: operator",
-        "operationId": "disableSupportAccessReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Server name",
-            "in": "path",
-            "name": "server",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Support access disabled successfully"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Disable support access",
-        "tags": [
-          "bare_metal"
-        ],
-        "x-requires-permissions": "team role: operator"
-      },
-      "put": {
-        "description": "Enables Hot Aisle support staff to access this server for troubleshooting.\n\n---\n\nRequires team role: operator",
-        "operationId": "enableSupportAccessReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Server name",
-            "in": "path",
-            "name": "server",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Support access enabled successfully"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Enable support access",
-        "tags": [
-          "bare_metal"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/teams/{team}/members/invitations/": {
-      "get": {
-        "description": "Returns a list of pending invitations for a team.\n\n---\n\nRequires team role: any",
-        "operationId": "getTeamInvitationsReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "List of team pending invitations",
-            "schema": {
-              "items": {
-                "$ref": "#/definitions/TeamMember"
-              },
-              "type": "array"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Get team's pending invitations",
-        "tags": [
-          "teams"
-        ],
-        "x-requires-permissions": "team role: any"
-      },
-      "post": {
-        "description": "Creates an invitation for a user to join a team.\n\n---\n\nRequires team role: owner",
-        "operationId": "createTeamInvitationReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/TeamInvitationRequest"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Invitation created successfully"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Invite a user to join the team",
-        "tags": [
-          "teams"
-        ],
-        "x-requires-permissions": "team role: owner"
-      }
-    },
-    "/teams/{team}/members/{email}/": {
-      "delete": {
-        "description": "Removes a member from a team. This can be: 1. Yourself (must be a contact owner) 2. Another member (must be a team owner) 3. A pending invitation (works as rejection)\n\n\n---\n\nRequires team role: owner (to delete another member) OR user role: owner (to delete self)",
-        "operationId": "removeTeamMemberReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Email address of the team member to remove",
-            "in": "path",
-            "name": "email",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Team member removed successfully"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Remove a member from a team",
-        "tags": [
-          "teams"
-        ],
-        "x-requires-permissions": "team role: owner (to delete another member) OR user role: owner (to delete self)"
-      },
-      "patch": {
-        "description": "Updates a team member's roles.\n\n---\n\nRequires team role: owner",
-        "operationId": "updateTeamMemberReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Email address of the team member to update",
-            "in": "path",
-            "name": "email",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/TeamMemberUpdate"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Team details",
-            "schema": {
-              "$ref": "#/definitions/TeamMember"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Update team member roles",
-        "tags": [
-          "teams"
-        ],
-        "x-requires-permissions": "team role: owner"
-      }
-    },
-    "/teams/{team}/purchase-credits/": {
-      "post": {
-        "description": "Creates a Stripe checkout session for purchasing credits for the team",
-        "operationId": "purchaseTeamCredits",
-        "parameters": [
-          {
-            "description": "Team slug",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Purchase details",
-            "in": "body",
-            "name": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/PurchaseTeamCreditsRequest"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successful operation",
-            "schema": {
-              "$ref": "#/definitions/PurchaseTeamCreditsResponse"
-            }
-          },
-          "202": {
-            "description": "Self-Service payment approval requested"
-          },
-          "400": {
-            "description": "Invalid request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden - user does not have purchaser role"
-          },
-          "404": {
-            "description": "Team not found"
-          },
-          "500": {
-            "description": "Internal server error"
-          }
-        },
-        "summary": "Purchase credits for a team",
-        "tags": [
-          "teams"
-        ]
-      }
-    },
-    "/teams/{team}/virtual_machines/": {
-      "get": {
-        "description": "Returns a list of virtual machines associated with the team.\n\n---\n\nRequires team role: any",
-        "operationId": "getVirtualMachinesReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "List of virtual machines with detailed specifications",
-            "schema": {
-              "items": {
-                "$ref": "#/definitions/VirtualMachineDetails"
-              },
-              "type": "array"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Get virtual machines",
-        "tags": [
-          "virtual_machines"
-        ],
-        "x-requires-permissions": "team role: any"
-      },
-      "post": {
-        "description": "Assigns and provisions an available virtual machine matching the specified requirements.\nOptionally provide a user_data_url to apply custom cloud-init configuration during provisioning. When provided, the VM will be assigned and then rebuilt with custom user-data applied. Default configuration will be applied as vendor-data and custom user-data will be merged.\nWARNING: Providing custom user-data will significantly increase provisioning time as the VM needs to be rebuilt. The provisioning will continue in the background if the HTTP request is canceled, but the VM will still be provisioned successfully.\n\n\n---\n\nRequires team role: operator",
-        "operationId": "assignAvailableVirtualMachineReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/VMProvisionRequest"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Successfully provisioned virtual machine",
-            "schema": {
-              "$ref": "#/definitions/VirtualMachineDetails"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "description": "Maximum VMs already provisioned for this team"
-          },
-          "402": {
-            "description": "Insufficient balance to provision virtual machine"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "description": "No available virtual machine matching requested specifications"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Provision a virtual machine",
-        "tags": [
-          "virtual_machines"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/teams/{team}/virtual_machines/available/": {
-      "get": {
-        "description": "Returns a list of available virtual machine types that can be provisioned, including pricing information.\n\n---\n\nRequires team role: any",
-        "operationId": "getAvailableVirtualMachinesReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "List of available virtual machine types with specifications and pricing",
-            "schema": {
-              "items": {
-                "$ref": "#/definitions/AvailableVirtualMachineTypes"
-              },
-              "type": "array"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Get available virtual machine types",
-        "tags": [
-          "virtual_machines"
-        ],
-        "x-requires-permissions": "team role: any"
-      }
-    },
-    "/teams/{team}/virtual_machines/{vm}/": {
-      "delete": {
-        "description": "Completely deletes a virtual machine and all its resources.\nWARNING: This operation will DELETE the VM and ALL of its data. This operation cannot be undone.\nThis request will not return until the reset is complete, but the reset will continue if the request is canceled.\n\n\n---\n\nRequires team role: operator",
-        "operationId": "deleteVMReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Virtual machine name",
-            "in": "path",
-            "name": "vm",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "VM deletion was successful"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Delete a virtual machine",
-        "tags": [
-          "virtual_machines"
-        ],
-        "x-requires-permissions": "team role: operator"
-      },
-      "get": {
-        "description": "Returns detailed information about a specific virtual machine.\n\n---\n\nRequires team role: any",
-        "operationId": "getVirtualMachineReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Virtual machine name",
-            "in": "path",
-            "name": "vm",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Detailed virtual machine specifications",
-            "schema": {
-              "$ref": "#/definitions/VirtualMachineDetails"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Get virtual machine details",
-        "tags": [
-          "virtual_machines"
-        ],
-        "x-requires-permissions": "team role: any"
-      },
-      "patch": {
-        "description": "Updates a vrutal machine's description.\n\n---\n\nRequires team role: operator",
-        "operationId": "updateVirtualMachineReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Virtual machine name",
-            "in": "path",
-            "name": "vm",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/VirtualMachineUpdate"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "Server updated successfully"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Update a virtual machine",
-        "tags": [
-          "virtual_machines"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/teams/{team}/virtual_machines/{vm}/console/": {
-      "get": {
-        "description": "Opens a WebSocket connection to the virtual machine's console\n\n---\n\nRequires team role: operator",
-        "operationId": "getVMConsoleReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Virtual machine name",
-            "in": "path",
-            "name": "vm",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "101": {
-            "description": "WebSocket connection established",
-            "schema": {
-              "format": "binary",
-              "type": "string"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Connect to virtual machine console",
-        "tags": [
-          "virtual_machines"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/teams/{team}/virtual_machines/{vm}/hard-reset/": {
-      "post": {
-        "description": "Forcefully resets a running virtual machine (equivalent to pressing the hardware reset button). This operation is abrupt and may result in data loss if the VM's filesystem is not properly synced. Use the graceful reboot endpoint when possible.\n\n\n---\n\nRequires team role: operator",
-        "operationId": "hardResetVMReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Virtual machine name",
-            "in": "path",
-            "name": "vm",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "VM hard reset operation was successful"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Forcefully reset a virtual machine",
-        "tags": [
-          "virtual_machines"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/teams/{team}/virtual_machines/{vm}/reboot/": {
-      "post": {
-        "description": "Gracefully reboots a running virtual machine by sending an ACPI reboot signal. This allows the guest OS to perform a clean shutdown and restart. This is the preferred way to restart a VM when possible.\n\n\n---\n\nRequires team role: operator",
-        "operationId": "rebootVMReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Virtual machine name",
-            "in": "path",
-            "name": "vm",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "VM reboot operation was successful"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Gracefully reboot a virtual machine",
-        "tags": [
-          "virtual_machines"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/teams/{team}/virtual_machines/{vm}/rebuild/": {
-      "post": {
-        "description": "Performs a complete rebuild of the virtual machine to its initial state.\nWARNING: This operation will DELETE ALL DATA on the virtual machine. The VM will be recreated from the original template, resulting in complete data loss. This operation cannot be undone.\nOptionally provide a user_data_url to apply custom cloud-init configuration during the rebuild. When provided, default configuration will be applied as vendor-data and custom user-data will be merged.\nThis request will not return until the rebuild is complete, but the rebuild will continue if the request is canceled.\n\n\n---\n\nRequires team role: operator",
-        "operationId": "rebuildVMReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Virtual machine name",
-            "in": "path",
-            "name": "vm",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "body",
-            "schema": {
-              "$ref": "#/definitions/VMResetRequest"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "VM rebuild operation was successful"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Rebuild a virtual machine in its initial state",
-        "tags": [
-          "virtual_machines"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/teams/{team}/virtual_machines/{vm}/shutdown/": {
-      "post": {
-        "description": "Sends a graceful shutdown signal to a running virtual machine.\n\n---\n\nRequires team role: operator",
-        "operationId": "shutdownVMReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Virtual machine name",
-            "in": "path",
-            "name": "vm",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "VM shutdown operation was successful"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Gracefully shutdown a virtual machine",
-        "tags": [
-          "virtual_machines"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/teams/{team}/virtual_machines/{vm}/start/": {
-      "post": {
-        "description": "Starts a virtual machine that is currently stopped.\n\n---\n\nRequires team role: operator",
-        "operationId": "startVMReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Virtual machine name",
-            "in": "path",
-            "name": "vm",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "VM start operation was successful"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Start a virtual machine",
-        "tags": [
-          "virtual_machines"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/teams/{team}/virtual_machines/{vm}/state/": {
-      "get": {
-        "description": "Returns the current power state of the virtual machine.\n\n---\n\nRequires team role: any",
-        "operationId": "getVMStateReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Virtual machine name",
-            "in": "path",
-            "name": "vm",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Current virtual machine state",
-            "schema": {
-              "$ref": "#/definitions/VirtualMachineState"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Get virtual machine state",
-        "tags": [
-          "virtual_machines"
-        ],
-        "x-requires-permissions": "team role: any"
-      }
-    },
-    "/teams/{team}/virtual_machines/{vm}/stop/": {
-      "post": {
-        "description": "Forcefully stops a running virtual machine (equivalent to pulling the power).\n\n---\n\nRequires team role: operator",
-        "operationId": "stopVMReq",
-        "parameters": [
-          {
-            "description": "Team handle",
-            "in": "path",
-            "name": "team",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "description": "Virtual machine name",
-            "in": "path",
-            "name": "vm",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "VM stop operation was successful"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Forcefully stop a virtual machine",
-        "tags": [
-          "virtual_machines"
-        ],
-        "x-requires-permissions": "team role: operator"
-      }
-    },
-    "/user/": {
-      "get": {
-        "description": "Returns user details including name, email, and account creation date for the authenticated user. Also includes information about the teams the user belongs to, including roles.\n\n\n---\n\nRequires user role: any",
-        "operationId": "getUserReq",
-        "responses": {
-          "200": {
-            "description": "User information with teams",
-            "schema": {
-              "$ref": "#/definitions/GetUserResponse"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Get information about the currently authenticated user.",
-        "tags": [
-          "user"
-        ],
-        "x-requires-permissions": "user role: any"
-      },
-      "patch": {
-        "description": "Allows updating user profile information such as display name.\n\n\n---\n\nRequires user role: owner",
-        "operationId": "updateUserReq",
-        "parameters": [
-          {
-            "in": "body",
-            "name": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/UserUpdate"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Updated user profile",
-            "schema": {
-              "$ref": "#/definitions/User"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Update the currently authenticated user profile.",
-        "tags": [
-          "user"
-        ],
-        "x-requires-permissions": "user role: owner"
-      }
-    },
-    "/user/api_keys/": {
-      "get": {
-        "description": "Returns a list of all API keys belonging to the user.\n\n---\n\nRequires user role: any",
-        "operationId": "getUserAPIKeysReq",
-        "responses": {
-          "200": {
-            "description": "List of API keys",
-            "schema": {
-              "items": {
-                "$ref": "#/definitions/UserAPIKey"
-              },
-              "type": "array"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Get user API keys",
-        "tags": [
-          "user"
-        ],
-        "x-requires-permissions": "user role: any"
-      },
-      "post": {
-        "description": "Creates a new API key with specified permissions.\n\n---\n\nRequires user role: owner",
-        "operationId": "createAPIKeyReq",
-        "parameters": [
-          {
-            "in": "body",
-            "name": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/UserAPIKeyRequest"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "API key created successfully, returns key details including one-time token",
-            "schema": {
-              "$ref": "#/definitions/UserAPIKeyWithToken"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Create a new API key",
-        "tags": [
-          "user"
-        ],
-        "x-requires-permissions": "user role: owner"
-      }
-    },
-    "/user/api_keys/{prefix}/": {
-      "delete": {
-        "description": "Permanently deletes an API key.\n\n---\n\nRequires user role: owner",
-        "operationId": "deleteAPIKeyReq",
-        "parameters": [
-          {
-            "description": "API key prefix identifier",
-            "in": "path",
-            "name": "prefix",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "API key successfully deleted"
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Delete an API key",
-        "tags": [
-          "user"
-        ],
-        "x-requires-permissions": "user role: owner"
-      },
-      "get": {
-        "description": "Returns detailed information about a specific API key.\n\n---\n\nRequires user role: any",
-        "operationId": "getUserAPIKeyDetailReq",
-        "parameters": [
-          {
-            "description": "API key prefix identifier",
-            "in": "path",
-            "name": "prefix",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "API key details",
-            "schema": {
-              "$ref": "#/definitions/UserAPIKey"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Get specific API key details",
-        "tags": [
-          "user"
-        ],
-        "x-requires-permissions": "user role: any"
-      },
-      "patch": {
-        "description": "Updates an existing API key with new permissions or label.\n\n---\n\nRequires user role: owner",
-        "operationId": "updateAPIKeyReq",
-        "parameters": [
-          {
-            "description": "API key prefix identifier",
-            "in": "path",
-            "name": "prefix",
-            "required": true,
-            "type": "string"
-          },
-          {
-            "in": "body",
-            "name": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/UserAPIKeyRequest"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "API key updated successfully",
-            "schema": {
-              "$ref": "#/definitions/UserAPIKey"
-            }
-          },
-          "400": {
-            "$ref": "#/responses/BadRequest"
-          },
-          "401": {
-            "$ref": "#/responses/Unauthorized"
-          },
-          "403": {
-            "$ref": "#/responses/Forbidden"
-          },
-          "404": {
-            "$ref": "#/responses/NotFound"
-          },
-          "422": {
-            "$ref": "#/responses/UnprocessableEntity"
-          },
-          "500": {
-            "$ref": "#/responses/InternalError"
-          }
-        },
-        "summary": "Update an API key",
-        "tags": [
-          "user"
-        ],
-        "x-requires-permissions": "user role: owner"
-      }
-    },
-    "/user/ssh_keys/": {
-      "get": {
-        "description": "Returns a list of all SSH keys belonging to the user.\n\n---\n\nRequires user role: any",
-        "operationId": "getUserSSHKeysReq",
-        "responses": {
-          "200": {
-            "description": "List of SSH keys",
-            "schema": {
-              "items": {
-                "$ref": "#/definitions/SSHKey"
-              },
-              "type": "array"
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        },
-        "summary": "Get user SSH keys",
-        "tags": [
-          "user",
-          "ssh"
-        ],
-        "x-requires-permissions": "user role: any"
-      },
-      "post": {
-        "description": "Adds a new SSH public key to the user's account.\n\n---\n\nRequires user role: owner",
-        "operationId": "addSSHKeyReq",
-        "parameters": [
-          {
-            "in": "body",
-            "name": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/SSHKeyRequest"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "SSH key added successfully",
-            "schema": {
-              "$ref": "#/definitions/SSHKey"
-            }
-          },
-          "400": {
-            "description": "Bad request - invalid input"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden - not a contact owner"
-          },
-          "409": {
-            "description": "Conflict - key already registered"
-          },
-          "422": {
-            "description": "Unprocessable Entity - invalid SSH key format"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        },
-        "summary": "Add a new SSH key",
-        "tags": [
-          "user",
-          "ssh"
-        ],
-        "x-requires-permissions": "user role: owner"
-      }
-    },
-    "/user/ssh_keys/{fingerprint}/": {
-      "delete": {
-        "description": "Permanently deletes an SSH key from the user's account.\n\n---\n\nRequires user role: owner",
-        "operationId": "deleteSSHKeyReq",
-        "parameters": [
-          {
-            "description": "SSH key fingerprint value (the part after \"SHA256:\" in the full fingerprint)",
-            "in": "path",
-            "name": "fingerprint",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "SSH key successfully deleted"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Forbidden - not a contact owner"
-          },
-          "404": {
-            "description": "SSH key not found"
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        },
-        "summary": "Delete an SSH key",
-        "tags": [
-          "user",
-          "ssh"
-        ],
-        "x-requires-permissions": "user role: owner"
-      }
-    }
-  },
-  "produces": [
-    "application/json"
-  ],
-  "responses": {
-    "BadRequest": {
-      "description": "Invalid request format or parameters",
-      "schema": {
-        "example": "Bad Request: Invalid input",
-        "type": "string"
-      }
-    },
-    "Error": {
-      "description": "Error response",
-      "schema": {
-        "example": "Error message",
-        "type": "string"
-      }
-    },
-    "Forbidden": {
-      "description": "Permission denied - the authenticated user doesn't have required permissions",
-      "schema": {
-        "example": "Forbidden: Permission denied",
-        "type": "string"
-      }
-    },
-    "InternalError": {
-      "description": "An unexpected error occurred on the server",
-      "schema": {
-        "example": "Internal Server Error",
-        "type": "string"
-      }
-    },
-    "NotFound": {
-      "description": "The requested resource was not found",
-      "schema": {
-        "example": "Not Found: Resource not found",
-        "type": "string"
-      }
-    },
-    "Unauthorized": {
-      "description": "Authentication information is missing or invalid",
-      "schema": {
-        "example": "Unauthorized",
-        "type": "string"
-      }
-    },
-    "UnprocessableEntity": {
-      "description": "Validation failed - request parameters are invalid",
-      "schema": {
-        "example": "Unprocessable Entity: Invalid data format",
-        "type": "string"
-      }
-    }
-  },
-  "security": [
-    {
-      "token": []
-    }
-  ],
-  "securityDefinitions": {
-    "token": {
-      "description": "Please enter in the word 'Token', a space, and then paste in your token.",
-      "in": "header",
-      "name": "Authorization",
-      "type": "apiKey"
-    }
-  },
-  "swagger": "2.0",
-  "tags": [
-    {
-      "name": "user"
-    },
-    {
-      "description": "Manage ssh key access to your servers.\n\nSSH Access is provided by the configuration in `/etc/ssh/sshd_config.d/70-hotaisle-auth-keys.conf` which dynamically fetches ssh keys from this API for your server on login. It caches these fetched keys to `~/.ssh/hotaisle_managed_keys`.\n\nIf you want to disable automatic key management, simply delete `/etc/ssh/sshd_config.d/70-hotaisle-auth-keys.conf`.\n\nSSH Keys associated with any member of a team with the `user` role will be permitted to login as the `hotaisle` user on a server.\n\nAdditionally if `support_access_enabled` is true, Hot Aisle support will also have access to the server.\n\nAutomatic key management does not touch the `~/.ssh/authorized_keys` file, so any changes you make there will not be reflected here. Additionally automatic key management does not affect any users except the `hotaisle` user.\n",
-      "name": "ssh"
-    },
-    {
-      "name": "teams"
-    },
-    {
-      "name": "bare_metal"
-    },
-    {
-      "name": "virtual_machines"
-    },
-    {
-      "name": "deprecated"
-    }
-  ]
+	"host": "admin.hotaisle.app",
+	"schemes": ["https"],
+	"basePath": "/api/",
+	"consumes": ["application/json"],
+	"definitions": {
+		"APIKeyTeam": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/Team"
+				},
+				{
+					"properties": {
+						"roles": {
+							"description": "The complete list of roles this API Key has on the team",
+							"example": ["owner", "purchaser", "operator"],
+							"items": {
+								"enum": ["owner", "purchaser", "operator", "user"],
+								"type": "string"
+							},
+							"type": "array",
+							"x-go-name": "Roles",
+							"x-order": "2"
+						}
+					},
+					"required": ["roles"],
+					"type": "object"
+				}
+			],
+			"description": "UserAPIKeyTeam represents a team that the API Key has access to",
+			"x-go-name": "UserAPIKeyTeam",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"AvailableBareMetalTypes": {
+			"description": "AvailableBareMetalTypes is how many bare metal servers of a given type are available to be reserved",
+			"properties": {
+				"MinimumReservationMinutes": {
+					"description": "Minimum reservation time in minutes",
+					"example": 480,
+					"format": "int64",
+					"type": "integer"
+				},
+				"OnDemandPrice": {
+					"description": "Price per hour for on-demand usage in US Cents",
+					"format": "int64",
+					"type": "integer"
+				},
+				"Quantity": {
+					"description": "Quantity of this server type available for reservation",
+					"example": 4,
+					"format": "int64",
+					"type": "integer"
+				},
+				"Specs": {
+					"$ref": "#/definitions/BareMetalServerSpecs"
+				}
+			},
+			"required": ["Quantity", "MinimumReservationMinutes"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"AvailableVirtualMachineTypes": {
+			"description": "AvailableVirtualTypes is how many virtual machines of a given type are available to be deployed",
+			"properties": {
+				"MinimumReservationMinutes": {
+					"description": "Minimum reservation time in minutes",
+					"example": 30,
+					"format": "int64",
+					"type": "integer"
+				},
+				"OnDemandPrice": {
+					"description": "Price per hour for on-demand usage in US Cents",
+					"format": "int64",
+					"type": "integer"
+				},
+				"Quantity": {
+					"description": "Quantity of this VM Type available for deployment",
+					"example": 4,
+					"format": "int64",
+					"type": "integer"
+				},
+				"Specs": {
+					"$ref": "#/definitions/VirtualMachineSpecs"
+				}
+			},
+			"required": ["Quantity", "MinimumReservationMinutes"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"BalanceInfo": {
+			"description": "BalanceInfo contains balance and estimated time until depletion",
+			"properties": {
+				"available_balance": {
+					"description": "Available balance in US cents (100 = $1.00)",
+					"example": 50000,
+					"format": "int64",
+					"type": "integer",
+					"x-go-name": "AvailableBalance"
+				},
+				"bare_metal_server_count": {
+					"description": "Number of active bare metal servers consuming balance",
+					"example": 1,
+					"format": "int64",
+					"type": "integer",
+					"x-go-name": "BareMetalServerCount"
+				},
+				"estimated_runout_time": {
+					"description": "Estimated time when balance will be completely depleted based on current resource usage",
+					"example": "2025-05-20T10:30:00Z",
+					"format": "date-time",
+					"type": "string",
+					"x-go-name": "EstimatedRunoutTime"
+				},
+				"hourly_rate": {
+					"description": "Total hourly cost of all active resources in US cents (100 = $1.00/hour)",
+					"example": 1250,
+					"format": "int64",
+					"type": "integer",
+					"x-go-name": "HourlyRate"
+				},
+				"minimum_balance": {
+					"description": "Minimum balance threshold in US cents (100 = $1.00). Only included when non-zero.",
+					"example": 1000,
+					"format": "int64",
+					"type": "integer",
+					"x-go-name": "MinimumBalance"
+				},
+				"virtual_machine_count": {
+					"description": "Number of active virtual machines consuming balance",
+					"example": 2,
+					"format": "int64",
+					"type": "integer",
+					"x-go-name": "VirtualMachineCount"
+				}
+			},
+			"required": [
+				"available_balance",
+				"hourly_rate",
+				"virtual_machine_count",
+				"bare_metal_server_count"
+			],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"BareMetalServer": {
+			"description": "BareMetalServer represents a bare metal server",
+			"properties": {
+				"description": {
+					"description": "Server description",
+					"example": "Production database server",
+					"type": "string",
+					"x-go-name": "Description"
+				},
+				"ip_address": {
+					"description": "Server's primary IP address",
+					"example": "192.168.1.100",
+					"type": "string",
+					"x-go-name": "IPAddress",
+					"x-go-type": "net/netip.Addr"
+				},
+				"manufacturer": {
+					"description": "Server manufacturer",
+					"example": "Dell",
+					"type": "string",
+					"x-go-name": "Manufacturer"
+				},
+				"model": {
+					"description": "Server model",
+					"example": "PowerEdge XE9680",
+					"type": "string",
+					"x-go-name": "Model"
+				},
+				"name": {
+					"description": "Server Name",
+					"example": "server-01",
+					"type": "string",
+					"x-go-name": "Name"
+				},
+				"ssh_access": {
+					"$ref": "#/definitions/ExternalService"
+				},
+				"support_access_enabled": {
+					"description": "Indicates if Hot Aisle Support is permitted to login to this server",
+					"type": "boolean",
+					"x-go-name": "SupportAccessEnabled"
+				}
+			},
+			"required": ["name", "ip_address", "manufacturer", "model"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"BareMetalServerConsoleURL": {
+			"description": "BareMetalServerConsoleURL has a temporary URL that can be used to access a local console",
+			"properties": {
+				"url": {
+					"description": "URL for console access",
+					"type": "string",
+					"x-go-name": "URL"
+				}
+			},
+			"required": ["url"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"BareMetalServerDetails": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/BareMetalServer"
+				},
+				{
+					"$ref": "#/definitions/BareMetalServerSpecs"
+				},
+				{
+					"properties": {
+						"os_status": {
+							"$ref": "#/definitions/BareMetalServerlOSStatus"
+						}
+					},
+					"type": "object"
+				}
+			],
+			"description": "BareMetalServerDetails represents a bare metal server with detailed hardware specifications",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"BareMetalServerPowerState": {
+			"description": "BareMetalServerPowerState represents the current power status of a server",
+			"properties": {
+				"state": {
+					"description": "The current power state of the server reported by iDrac.\nValues can be \"On\" or \"Off\".",
+					"enum": ["On", "Off"],
+					"example": "On",
+					"type": "string",
+					"x-go-name": "State"
+				}
+			},
+			"required": ["state"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"BareMetalServerReservation": {
+			"description": "BareMetalServerReservation represents a request to reserve a bare metal server",
+			"properties": {
+				"description": {
+					"description": "Server description",
+					"example": "Production GPU server for machine learning workloads",
+					"type": "string",
+					"x-go-name": "Description"
+				},
+				"specs": {
+					"$ref": "#/definitions/BareMetalServerSpecs"
+				}
+			},
+			"required": ["specs"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"BareMetalServerReservationResponse": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/BareMetalServer"
+				},
+				{
+					"properties": {
+						"cpu_cores": {
+							"description": "Total CPU Cores",
+							"example": 64,
+							"format": "uint64",
+							"type": "integer",
+							"x-go-name": "CPUCores"
+						},
+						"cpus": {
+							"description": "Detailed CPU information",
+							"items": {
+								"$ref": "#/definitions/CPUs"
+							},
+							"type": "array",
+							"x-go-name": "CPUs"
+						},
+						"disk_capacity": {
+							"description": "Total Disk in bytes",
+							"example": 4398046511104,
+							"format": "uint64",
+							"type": "integer",
+							"x-go-name": "DiskCapacity"
+						},
+						"disks": {
+							"description": "Detailed disk information",
+							"items": {
+								"$ref": "#/definitions/Disks"
+							},
+							"type": "array",
+							"x-go-name": "Disks"
+						},
+						"gpus": {
+							"description": "Detailed GPU information if present",
+							"items": {
+								"$ref": "#/definitions/GPUs"
+							},
+							"type": "array",
+							"x-go-name": "GPUs"
+						},
+						"memory_modules": {
+							"description": "Detailed memory module information",
+							"items": {
+								"$ref": "#/definitions/MemoryModules"
+							},
+							"type": "array",
+							"x-go-name": "MemoryModules"
+						},
+						"os_status": {
+							"$ref": "#/definitions/BareMetalServerlOSStatus"
+						},
+						"ram_capacity": {
+							"description": "Total RAM in bytes",
+							"example": 549755813888,
+							"format": "uint64",
+							"type": "integer",
+							"x-go-name": "RAMCapacity"
+						}
+					},
+					"required": ["cpu_cores", "ram_capacity", "disk_capacity"],
+					"type": "object"
+				}
+			],
+			"description": "BareMetalServerReservationResponse represents the response after successfully reserving a server",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"BareMetalServerSpecs": {
+			"description": "BareMetalServerSpecs contains the hardware specifications of a server",
+			"properties": {
+				"cpu_cores": {
+					"description": "Total CPU Cores",
+					"example": 64,
+					"format": "uint64",
+					"type": "integer",
+					"x-go-name": "CPUCores"
+				},
+				"cpus": {
+					"description": "Detailed CPU information",
+					"items": {
+						"$ref": "#/definitions/CPUs"
+					},
+					"type": "array",
+					"x-go-name": "CPUs"
+				},
+				"disk_capacity": {
+					"description": "Total Disk in bytes",
+					"example": 4398046511104,
+					"format": "uint64",
+					"type": "integer",
+					"x-go-name": "DiskCapacity"
+				},
+				"disks": {
+					"description": "Detailed disk information",
+					"items": {
+						"$ref": "#/definitions/Disks"
+					},
+					"type": "array",
+					"x-go-name": "Disks"
+				},
+				"gpus": {
+					"description": "Detailed GPU information if present",
+					"items": {
+						"$ref": "#/definitions/GPUs"
+					},
+					"type": "array",
+					"x-go-name": "GPUs"
+				},
+				"memory_modules": {
+					"description": "Detailed memory module information",
+					"items": {
+						"$ref": "#/definitions/MemoryModules"
+					},
+					"type": "array",
+					"x-go-name": "MemoryModules"
+				},
+				"ram_capacity": {
+					"description": "Total RAM in bytes",
+					"example": 549755813888,
+					"format": "uint64",
+					"type": "integer",
+					"x-go-name": "RAMCapacity"
+				}
+			},
+			"required": ["cpu_cores", "ram_capacity", "disk_capacity"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"BareMetalServerUpdate": {
+			"description": "BareMetalServerUpdate represents a bare metal server",
+			"properties": {
+				"description": {
+					"description": "Bare Metal Server description",
+					"type": "string",
+					"x-go-name": "Description"
+				}
+			},
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"BareMetalServerlOSStatus": {
+			"description": "BareMetalServerlOSStatus represents the current state of OS installation on a server",
+			"properties": {
+				"last_imaging_update": {
+					"description": "Last Imaging Update Timestamp\n\nThe date and time when the OS installation status was last updated\nCan be used to track progress and determine if the installation process is active",
+					"example": "2024-12-10T19:20:04.825Z",
+					"format": "date-time",
+					"type": "string",
+					"x-go-name": "LastImagingUpdate"
+				},
+				"os_install_status": {
+					"description": "OS Install Status\n\nThe current stage in the OS installation process.\nProgresses through various states from \"shutting_down\" through \"installing_os\" to \"installed\" or \"failed\" if an error occurs",
+					"enum": [
+						"shutting_down",
+						"ac_reset",
+						"bios_reset",
+						"booting_installer",
+						"installing_os",
+						"finalizing_os",
+						"first_boot",
+						"first_boot_tasks",
+						"installed",
+						"failed"
+					],
+					"example": "installed",
+					"type": "string",
+					"x-go-name": "OSStatus"
+				},
+				"os_selection": {
+					"description": "OS Selection",
+					"enum": ["ubuntu-2204.5", "ubuntu-2404.4", "ubuntu-2604"],
+					"example": "ubuntu-2204.5",
+					"type": "string",
+					"x-go-name": "OSSelection"
+				}
+			},
+			"required": ["os_selection", "os_install_status", "last_imaging_update"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"CPUs": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/Components"
+				},
+				{
+					"properties": {
+						"cores": {
+							"description": "Cores per processor",
+							"example": 32,
+							"format": "uint64",
+							"type": "integer",
+							"x-go-name": "Cores"
+						},
+						"frequency": {
+							"description": "CPU Frequency in Hertz",
+							"example": 2600000000,
+							"format": "uint64",
+							"type": "integer",
+							"x-go-name": "Frequency"
+						}
+					},
+					"required": ["cores", "frequency"],
+					"type": "object"
+				}
+			],
+			"description": "CPUs represents processor information",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"Components": {
+			"description": "Components represents common attributes for hardware components",
+			"properties": {
+				"count": {
+					"description": "Number of components of this type",
+					"example": 4,
+					"format": "uint64",
+					"type": "integer",
+					"x-go-name": "Count"
+				},
+				"manufacturer": {
+					"description": "Component manufacturer",
+					"example": "Intel",
+					"type": "string",
+					"x-go-name": "Manufacturer"
+				},
+				"model": {
+					"description": "Component model",
+					"example": "Xeon Platinum 8470",
+					"type": "string",
+					"x-go-name": "Model"
+				}
+			},
+			"required": ["count", "manufacturer", "model"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"Disks": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/Components"
+				},
+				{
+					"properties": {
+						"capacity": {
+							"description": "Capacity in bytes per disk",
+							"example": 1099511627776,
+							"format": "uint64",
+							"type": "integer",
+							"x-go-name": "Capacity"
+						},
+						"type": {
+							"description": "Disk type, NVMe or SATA-SSD",
+							"enum": ["NVMe", "SATA SSD"],
+							"example": "NVMe",
+							"type": "string",
+							"x-go-name": "Type"
+						}
+					},
+					"required": ["type", "capacity"],
+					"type": "object"
+				}
+			],
+			"description": "Disks represents storage device information",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"EmailCodeRequest": {
+			"description": "EmailCodeRequest contains the email address for requesting a sign-in code",
+			"properties": {
+				"email": {
+					"description": "User's email address",
+					"example": "john.doe@example.com",
+					"type": "string",
+					"x-go-name": "Email"
+				}
+			},
+			"required": ["email"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"ExternalService": {
+			"description": "ExternalService represents information about an externally accessible service",
+			"properties": {
+				"dns_name": {
+					"description": "DNS hostname for the service if available",
+					"example": "server1.example.com",
+					"type": "string",
+					"x-go-name": "DNSName"
+				},
+				"ip_address": {
+					"description": "Public IP address for service access",
+					"example": "203.0.113.10",
+					"type": "string",
+					"x-go-name": "IPAddress",
+					"x-go-type": "net/netip.Addr"
+				},
+				"port": {
+					"description": "Service port number",
+					"example": 22,
+					"format": "int64",
+					"type": "integer",
+					"x-go-name": "Port"
+				}
+			},
+			"required": ["ip_address", "port"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"GPUs": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/Components"
+				}
+			],
+			"description": "GPUs represents graphics processing unit information",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"GetUserResponse": {
+			"description": "GetUserResponse represents information about the authenticated user and their teams",
+			"properties": {
+				"teams": {
+					"description": "Teams the user belongs to",
+					"items": {
+						"$ref": "#/definitions/UserTeam"
+					},
+					"type": "array",
+					"x-go-name": "Teams"
+				},
+				"user": {
+					"$ref": "#/definitions/User"
+				}
+			},
+			"required": ["user", "teams"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"MemoryModules": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/Components"
+				},
+				{
+					"properties": {
+						"capacity": {
+							"description": "Capacity in bytes per module",
+							"example": 34359738368,
+							"format": "uint64",
+							"type": "integer",
+							"x-go-name": "Capacity"
+						}
+					},
+					"required": ["capacity"],
+					"type": "object"
+				}
+			],
+			"description": "MemoryModules represents memory module information",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"PurchaseTeamCreditsRequest": {
+			"description": "PurchaseTeamCreditsRequest represents a request to purchase credits for a team",
+			"properties": {
+				"cents": {
+					"description": "The amount to purchase in US cents (100 = $1.00)",
+					"example": 10000,
+					"format": "int64",
+					"minimum": 2000,
+					"type": "integer",
+					"x-go-name": "Cents"
+				}
+			},
+			"required": ["cents"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"PurchaseTeamCreditsResponse": {
+			"description": "PurchaseTeamCreditsResponse represents the response to a credits purchase request",
+			"properties": {
+				"checkout_url": {
+					"description": "URL to the Stripe Checkout page where the customer can complete payment",
+					"example": "https://checkout.stripe.com/c/pay/cs_test_a1b2c3...",
+					"type": "string",
+					"x-go-name": "CheckoutURL"
+				},
+				"expires_at": {
+					"description": "Expiration time of the checkout session",
+					"example": "2025-05-16T15:30:00Z",
+					"format": "date-time",
+					"type": "string",
+					"x-go-name": "ExpiresAt"
+				}
+			},
+			"required": ["checkout_url", "expires_at"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"RegistrationRequest": {
+			"description": "RegistrationRequest contains the information needed to register a new user",
+			"properties": {
+				"email": {
+					"description": "User's email address",
+					"example": "john.doe@example.com",
+					"type": "string",
+					"x-go-name": "Email"
+				},
+				"name": {
+					"description": "User's full name",
+					"example": "John Doe",
+					"type": "string",
+					"x-go-name": "Name"
+				}
+			},
+			"required": ["name", "email"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"RequestPaymentApprovalRequest": {
+			"description": "RequestPaymentApprovalRequest represents a request for self-service payment approval",
+			"properties": {
+				"message": {
+					"description": "Message from the requesting team explaining what they're building",
+					"example": "We're building a machine learning platform and need GPU resources for training models.",
+					"type": "string",
+					"x-go-name": "Message"
+				}
+			},
+			"required": ["message"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"SSHKey": {
+			"description": "SSHKey represents an SSH public key associated with a user",
+			"properties": {
+				"comment": {
+					"description": "A descriptive comment or label for the key",
+					"example": "user@example.com",
+					"type": "string",
+					"x-go-name": "Comment"
+				},
+				"fingerprint": {
+					"description": "The unique fingerprint of the SSH key",
+					"example": "SHA256:AbCdEfGhIjKlMnOpQrStUvWxYz12345678901234",
+					"type": "string",
+					"x-go-name": "Fingerprint"
+				},
+				"public_key": {
+					"description": "The base64-encoded public key portion",
+					"example": "AAAAB3NzaC1yc2EAAAADAQABAAABgQC...",
+					"type": "string",
+					"x-go-name": "PublicKey"
+				},
+				"type": {
+					"description": "The type of SSH key (e.g., ssh-rsa, ssh-ed25519)",
+					"example": "ssh-rsa",
+					"type": "string",
+					"x-go-name": "Type"
+				}
+			},
+			"required": ["type", "public_key", "fingerprint"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"SSHKeyRequest": {
+			"description": "SSHKeyRequest represents the data needed to add a new SSH key",
+			"properties": {
+				"authorized_key": {
+					"description": "SSH public key in the authorized key format of \u003ctype\u003e \u003cpublic_key\u003e \u003ccomment\u003e",
+					"example": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC... user@example.com",
+					"type": "string",
+					"x-go-name": "AuthorizedKey"
+				}
+			},
+			"required": ["authorized_key"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"Session": {
+			"description": "Session represents an active session with its associated API key information",
+			"properties": {
+				"api_key_prefix": {
+					"description": "The associated API key prefix, if one exists",
+					"example": "b2c3d4e5f6g7h8i9j0k1l2m3n4",
+					"type": "string",
+					"x-go-name": "APIKeyPrefix"
+				},
+				"created": {
+					"description": "When this session was created",
+					"example": "2025-04-10T14:30:00Z",
+					"format": "date-time",
+					"type": "string",
+					"x-go-name": "Created"
+				},
+				"expires_at": {
+					"description": "When this session will expire",
+					"example": "2025-04-17T14:30:00Z",
+					"format": "date-time",
+					"type": "string",
+					"x-go-name": "ExpiresAt"
+				},
+				"prefix": {
+					"description": "The unique prefix identifier for this session",
+					"example": "a1b2c3d4e5f6g7h8i9j0k1l2m3",
+					"type": "string",
+					"x-go-name": "Prefix"
+				}
+			},
+			"required": ["prefix", "expires_at", "created"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"Team": {
+			"description": "Team represents a team",
+			"properties": {
+				"description": {
+					"description": "Team description",
+					"type": "string",
+					"x-go-name": "Description",
+					"x-order": "2"
+				},
+				"handle": {
+					"description": "Team's unique identifier handle",
+					"example": "acme-corporation",
+					"type": "string",
+					"x-go-name": "Handle",
+					"x-order": "0"
+				},
+				"maximum_bare_metal_servers": {
+					"description": "Maximum number of bare metal servers this team can create",
+					"example": 5,
+					"format": "int64",
+					"type": "integer",
+					"x-go-name": "MaximumBareMetalServers",
+					"x-order": "5"
+				},
+				"maximum_virtual_machines": {
+					"description": "Maximum number of virtual machines this team can create",
+					"example": 10,
+					"format": "int64",
+					"type": "integer",
+					"x-go-name": "MaximumVirtualMachines",
+					"x-order": "4"
+				},
+				"name": {
+					"description": "Team's display name",
+					"example": "Acme Corporation",
+					"type": "string",
+					"x-go-name": "Name",
+					"x-order": "1"
+				}
+			},
+			"required": ["handle", "name"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"TeamInvitationRequest": {
+			"description": "TeamInvitationRequest contains the information needed to invite a user to a team",
+			"properties": {
+				"email": {
+					"description": "Invitee's email address",
+					"example": "john.doe@example.com",
+					"maxLength": 254,
+					"type": "string",
+					"x-go-name": "Email"
+				},
+				"name": {
+					"description": "Invitee's full name",
+					"example": "John Doe",
+					"maxLength": 100,
+					"type": "string",
+					"x-go-name": "Name"
+				},
+				"roles": {
+					"description": "Roles to assign to the invitee",
+					"example": ["operator", "user"],
+					"items": {
+						"enum": ["owner", "purchaser", "operator", "user"],
+						"type": "string"
+					},
+					"type": "array",
+					"x-go-name": "Roles"
+				}
+			},
+			"required": ["name", "email", "roles"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"TeamMember": {
+			"description": "TeamMember represents a team member or pending invitation",
+			"properties": {
+				"created": {
+					"description": "When the user account was created",
+					"example": "2025-04-10T14:30:00Z",
+					"format": "date-time",
+					"type": "string",
+					"x-go-name": "Created"
+				},
+				"email": {
+					"description": "User's email address",
+					"example": "john.doe@example.com",
+					"type": "string",
+					"x-go-name": "Email"
+				},
+				"invitation": {
+					"description": "This team membership is a invite that has not yet been accepted",
+					"example": true,
+					"type": "boolean",
+					"x-go-name": "Invitation"
+				},
+				"name": {
+					"description": "User's full name",
+					"example": "John Doe",
+					"type": "string",
+					"x-go-name": "Name"
+				},
+				"roles": {
+					"description": "The complete list of roles this user has on the team",
+					"example": ["owner", "purchaser", "operator"],
+					"items": {
+						"enum": ["owner", "purchaser", "operator", "user"],
+						"type": "string"
+					},
+					"type": "array",
+					"x-go-name": "Roles"
+				}
+			},
+			"required": ["name", "email", "created", "roles"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"TeamMemberUpdate": {
+			"description": "TeamMemberUpdate represents the data needed to update a team member's roles",
+			"properties": {
+				"roles": {
+					"description": "Updated roles for the team member",
+					"example": ["operator", "user"],
+					"items": {
+						"enum": ["owner", "purchaser", "operator", "user"],
+						"type": "string"
+					},
+					"type": "array",
+					"x-go-name": "Roles"
+				}
+			},
+			"required": ["roles"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"TeamUpdate": {
+			"description": "TeamUpdate represents a team",
+			"properties": {
+				"description": {
+					"description": "Team description",
+					"type": "string",
+					"x-go-name": "Description",
+					"x-order": "2"
+				},
+				"handle": {
+					"description": "Team's unique identifier handle",
+					"example": "acme-corporation",
+					"type": "string",
+					"x-go-name": "Handle",
+					"x-order": "0"
+				},
+				"name": {
+					"description": "Team's display name",
+					"example": "Acme Corporation",
+					"type": "string",
+					"x-go-name": "Name",
+					"x-order": "1"
+				}
+			},
+			"required": ["handle", "name"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"User": {
+			"description": "User represents a registered user in the system",
+			"properties": {
+				"created": {
+					"description": "When the user account was created",
+					"example": "2025-04-10T14:30:00Z",
+					"format": "date-time",
+					"type": "string",
+					"x-go-name": "Created"
+				},
+				"email": {
+					"description": "User's email address",
+					"example": "john.doe@example.com",
+					"type": "string",
+					"x-go-name": "Email"
+				},
+				"name": {
+					"description": "User's full name",
+					"example": "John Doe",
+					"type": "string",
+					"x-go-name": "Name"
+				}
+			},
+			"required": ["name", "email", "created"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"UserAPIKey": {
+			"description": "UserAPIKey represents a user's API key",
+			"properties": {
+				"label": {
+					"description": "A descriptive label for the API key",
+					"example": "Development key",
+					"type": "string",
+					"x-go-name": "Label",
+					"x-order": "2"
+				},
+				"prefix": {
+					"description": "The unique prefix of this API key (used for identification)",
+					"example": "6ddfaa4539b4c7e046fe4b94",
+					"type": "string",
+					"x-go-name": "Prefix",
+					"x-order": "0"
+				},
+				"teams": {
+					"description": "Teams that this API key has access to and the roles on each team",
+					"items": {
+						"$ref": "#/definitions/APIKeyTeam"
+					},
+					"type": "array",
+					"x-go-name": "Teams",
+					"x-order": "4"
+				},
+				"user_role": {
+					"description": "The role this API Key has on the user\nKeys with a user role of 'owner' can modify the user, including changing name, leaving or accepting invites to teams, and creating api keys",
+					"enum": ["owner", "user"],
+					"example": "owner",
+					"type": "string",
+					"x-go-name": "UserRole",
+					"x-order": "3"
+				}
+			},
+			"required": ["user_role"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"UserAPIKeyRequest": {
+			"description": "UserAPIKeyRequest represents the data needed to create or update an API key",
+			"properties": {
+				"label": {
+					"description": "A descriptive label for the API key",
+					"example": "Development key",
+					"type": "string",
+					"x-go-name": "Label",
+					"x-order": "0"
+				},
+				"teams": {
+					"description": "Teams and their associated permissions for this API key",
+					"items": {
+						"$ref": "#/definitions/UserAPIKeyTeamRoles"
+					},
+					"type": "array",
+					"x-go-name": "Teams",
+					"x-order": "2"
+				},
+				"user_role": {
+					"description": "The role this API key has on the user",
+					"enum": ["owner", "user"],
+					"example": "user",
+					"type": "string",
+					"x-go-name": "UserRole",
+					"x-order": "1"
+				}
+			},
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"UserAPIKeyTeamRoles": {
+			"description": "UserAPIKeyTeamRoles defines the permissions for an API key on a specific team",
+			"properties": {
+				"roles": {
+					"description": "The roles assigned to this API key for the team wtf man",
+					"example": ["operator", "user"],
+					"items": {
+						"enum": ["owner", "purchaser", "operator", "user"],
+						"type": "string"
+					},
+					"type": "array",
+					"x-go-name": "Roles"
+				},
+				"team": {
+					"description": "Team slug identifier",
+					"example": "hotaisle-development",
+					"type": "string",
+					"x-go-name": "Team"
+				}
+			},
+			"required": ["team", "roles"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"UserAPIKeyWithToken": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/UserAPIKey"
+				},
+				{
+					"properties": {
+						"token": {
+							"description": "The full token value. This is the only time the full token will be returned, as it is not stored plaintext on the server and cannot be recovered.",
+							"example": "6ddfaa4539b4c7e046fe4b94.ee7003caf1bca1c01bb37b7a870af156d29bfdd5d86113eef99e2f476f91659c",
+							"type": "string",
+							"x-go-name": "Token"
+						}
+					},
+					"type": "object"
+				}
+			],
+			"description": "UserAPIKeyWithToken represents an API key with its full token value\nOnly returned when creating a new API key",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"UserEmailCodeResponse": {
+			"description": "UserEmailCodeResponse contains information about a sign-in code request",
+			"properties": {
+				"code_expires": {
+					"description": "When the sign-in code expires",
+					"example": "2025-04-10T15:30:00Z",
+					"format": "date-time",
+					"type": "string",
+					"x-go-name": "CodeExpires"
+				},
+				"email": {
+					"description": "User's email address",
+					"example": "john.doe@example.com",
+					"type": "string",
+					"x-go-name": "Email"
+				}
+			},
+			"required": ["email", "code_expires"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"UserRegistrationResponse": {
+			"description": "UserRegistrationResponse contains information about a registration attempt",
+			"properties": {
+				"code_expires": {
+					"description": "When the sign-in code expires",
+					"example": "2025-04-10T15:30:00Z",
+					"format": "date-time",
+					"type": "string",
+					"x-go-name": "CodeExpires"
+				},
+				"email": {
+					"description": "User's email address",
+					"example": "john.doe@example.com",
+					"type": "string",
+					"x-go-name": "Email"
+				},
+				"name": {
+					"description": "User's full name",
+					"example": "John Doe",
+					"type": "string",
+					"x-go-name": "Name"
+				}
+			},
+			"required": ["name", "email", "code_expires"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"UserTeam": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/Team"
+				},
+				{
+					"properties": {
+						"effective_roles": {
+							"description": "The list of effective roles that this authenticated request has, based on API Key restrictions",
+							"example": ["operator", "user"],
+							"items": {
+								"enum": ["owner", "purchaser", "operator", "user"],
+								"type": "string"
+							},
+							"type": "array",
+							"x-go-name": "EffectiveRoles",
+							"x-order": "4"
+						},
+						"invitation": {
+							"description": "This team membership is a invite that has not yet been accepted",
+							"example": true,
+							"type": "boolean",
+							"x-go-name": "Invitation",
+							"x-order": "5"
+						},
+						"roles": {
+							"description": "The complete list of roles this user has on the team",
+							"example": ["owner", "purchaser", "operator"],
+							"items": {
+								"enum": ["owner", "purchaser", "operator", "user"],
+								"type": "string"
+							},
+							"type": "array",
+							"x-go-name": "Roles",
+							"x-order": "3"
+						}
+					},
+					"required": ["roles", "effective_roles"],
+					"type": "object"
+				}
+			],
+			"description": "UserTeam represents a team that the user belongs to",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"UserTeamDetails": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/UserTeamWithMembers"
+				},
+				{
+					"properties": {
+						"bare_metal_servers": {
+							"description": "Bare metal servers",
+							"items": {
+								"$ref": "#/definitions/BareMetalServer"
+							},
+							"type": "array",
+							"x-go-name": "BareMetalServers",
+							"x-order": "7"
+						},
+						"virtual_machines": {
+							"description": "Virtual Machines",
+							"items": {
+								"$ref": "#/definitions/VirtualMachine"
+							},
+							"type": "array",
+							"x-go-name": "VirtualMachines",
+							"x-order": "8"
+						}
+					},
+					"type": "object"
+				}
+			],
+			"description": "UserTeamWithMembers represents a team with detailed information including members and resources",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"UserTeamWithMembers": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/UserTeam"
+				},
+				{
+					"properties": {
+						"members": {
+							"description": "Team members",
+							"items": {
+								"$ref": "#/definitions/TeamMember"
+							},
+							"type": "array",
+							"x-go-name": "Members",
+							"x-order": "6"
+						}
+					},
+					"type": "object"
+				}
+			],
+			"description": "UserTeamWithMembers represents a team with detailed member information",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"UserUpdate": {
+			"description": "UserUpdate represents the updateable fields for a user",
+			"properties": {
+				"name": {
+					"description": "User's full name",
+					"example": "Jane Smith",
+					"type": "string",
+					"x-go-name": "Name"
+				}
+			},
+			"required": ["name"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"VMProvisionRequest": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/VirtualMachineSpecs"
+				},
+				{
+					"properties": {
+						"user_data_url": {
+							"description": "Optional URL to custom cloud-init user-data\nWhen provided, the VM will be provisioned with this user-data applied\nNote: This will significantly increase provisioning time as the VM will be rebuilt",
+							"example": "https://example.com/my-user-data.yaml",
+							"type": "string",
+							"x-go-name": "UserDataURL"
+						}
+					},
+					"type": "object"
+				}
+			],
+			"description": "VMProvisionRequest represents a request to provision a virtual machine",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"VMResetRequest": {
+			"description": "VMResetRequest represents a request to reset/rebuild a virtual machine",
+			"properties": {
+				"user_data_url": {
+					"description": "Optional URL to custom cloud-init user-data\nWhen provided, the VM will be rebuilt with this user-data applied",
+					"example": "https://example.com/my-user-data.yaml",
+					"type": "string",
+					"x-go-name": "UserDataURL"
+				}
+			},
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"VirtualMachine": {
+			"description": "VirtualMachine represents a virtual machine instance",
+			"properties": {
+				"description": {
+					"description": "VM description",
+					"example": "Production web server",
+					"type": "string",
+					"x-go-name": "Description"
+				},
+				"ip_address": {
+					"description": "VM's primary IP address",
+					"example": "192.168.1.200",
+					"type": "string",
+					"x-go-name": "IPAddress",
+					"x-go-type": "net/netip.Addr"
+				},
+				"name": {
+					"description": "VM Name",
+					"example": "vm-01",
+					"type": "string",
+					"x-go-name": "Name"
+				},
+				"ssh_access": {
+					"$ref": "#/definitions/ExternalService"
+				}
+			},
+			"required": ["name", "ip_address"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"VirtualMachineDetails": {
+			"allOf": [
+				{
+					"$ref": "#/definitions/VirtualMachine"
+				},
+				{
+					"$ref": "#/definitions/VirtualMachineSpecs"
+				}
+			],
+			"description": "VirtualMachineDetails represents a virtual machine with detailed specifications",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"VirtualMachineSpecs": {
+			"description": "VirtualMachineSpecs contains the specifications of a virtual machine",
+			"properties": {
+				"cpu_cores": {
+					"description": "Total CPU Cores",
+					"example": 8,
+					"format": "uint64",
+					"type": "integer",
+					"x-go-name": "CPUCores"
+				},
+				"cpus": {
+					"$ref": "#/definitions/CPUs"
+				},
+				"disk_capacity": {
+					"description": "Total Disk in bytes",
+					"example": 107374182400,
+					"format": "uint64",
+					"type": "integer",
+					"x-go-name": "DiskCapacity"
+				},
+				"gpus": {
+					"description": "GPU information if any GPUs are assigned",
+					"items": {
+						"$ref": "#/definitions/GPUs"
+					},
+					"type": "array",
+					"x-go-name": "GPUs"
+				},
+				"ram_capacity": {
+					"description": "Total RAM in bytes",
+					"example": 34359738368,
+					"format": "uint64",
+					"type": "integer",
+					"x-go-name": "RAMCapacity"
+				}
+			},
+			"required": ["cpu_cores", "ram_capacity", "disk_capacity"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"VirtualMachineState": {
+			"description": "VirtualMachineState represents the current state of a virtual machine",
+			"properties": {
+				"host": {
+					"description": "The host where the VM is running",
+					"example": "vm-host-01",
+					"type": "string",
+					"x-go-name": "Host"
+				},
+				"state": {
+					"description": "The current state of the virtual machine.\nValues can include \"running\", \"shut off\", \"paused\", etc.",
+					"example": "running",
+					"type": "string",
+					"x-go-name": "State"
+				}
+			},
+			"required": ["state", "host"],
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		},
+		"VirtualMachineUpdate": {
+			"description": "VirtualMachineUpdate represents a bare metal server",
+			"properties": {
+				"description": {
+					"description": "Virtual Machine description",
+					"type": "string",
+					"x-go-name": "Description"
+				}
+			},
+			"type": "object",
+			"x-go-package": "github.com/hotaisle/hotManager/api/types"
+		}
+	},
+	"info": {
+		"description": "Hot Aisle API\n",
+		"title": "hotaisle",
+		"version": "1.0.0"
+	},
+	"paths": {
+		"/teams/": {
+			"get": {
+				"description": "Returns information about the teams the user belongs to, including roles.\n\n---\n\nRequires team role: any (only returns teams for which this API key has a role)",
+				"operationId": "getUserTeamsReq",
+				"responses": {
+					"200": {
+						"description": "User information with teams",
+						"schema": {
+							"items": {
+								"$ref": "#/definitions/UserTeam"
+							},
+							"type": "array"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Get user team membership",
+				"tags": ["teams"],
+				"x-requires-permissions": "team role: any (only returns teams for which this API key has a role)"
+			},
+			"post": {
+				"description": "Creates a new team with the authenticated user as the owner.\n\n\n---\n\nRequires user role: owner",
+				"operationId": "createTeamReq",
+				"parameters": [
+					{
+						"in": "body",
+						"name": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/Team"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Team created successfully",
+						"schema": {
+							"$ref": "#/definitions/UserTeamWithMembers"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Create a new team",
+				"tags": ["teams"],
+				"x-requires-permissions": "user role: owner"
+			}
+		},
+		"/teams/invitations/": {
+			"get": {
+				"description": "Returns information about the team invitations that are pending for the user.\n\n---\n\nRequires user role: any",
+				"operationId": "getUserTeamsInvitationsReq",
+				"responses": {
+					"200": {
+						"description": "List of pending team invitations",
+						"schema": {
+							"items": {
+								"$ref": "#/definitions/UserTeam"
+							},
+							"type": "array"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Get user pending team invitations",
+				"tags": ["teams"],
+				"x-requires-permissions": "user role: any"
+			}
+		},
+		"/teams/{team}/": {
+			"get": {
+				"description": "Returns detailed information about a specific team the user belongs to.\n\n---\n\nRequires team role: any",
+				"operationId": "getUserTeamDetailReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Team details",
+						"schema": {
+							"$ref": "#/definitions/UserTeamDetails"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Get specific team details",
+				"tags": ["teams"],
+				"x-requires-permissions": "team role: any"
+			},
+			"patch": {
+				"description": "Updates a team's details.\n\n---\n\nRequires team role: owner",
+				"operationId": "updateTeamReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"in": "body",
+						"name": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/TeamUpdate"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Team updated successfully",
+						"schema": {
+							"$ref": "#/definitions/UserTeamWithMembers"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Update a team's information",
+				"tags": ["teams"],
+				"x-requires-permissions": "team role: owner"
+			}
+		},
+		"/teams/{team}/accept-invitation/": {
+			"post": {
+				"description": "Accept a pending invitation to join a team.\n\n---\n\nRequires user role: owner",
+				"operationId": "acceptTeamInvitationReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Invitation accepted, returns updated team details",
+						"schema": {
+							"$ref": "#/definitions/UserTeamWithMembers"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Accept team invitation",
+				"tags": ["teams"],
+				"x-requires-permissions": "user role: owner"
+			}
+		},
+		"/teams/{team}/balance/": {
+			"get": {
+				"description": "Returns the current available balance, estimated runout time, and hourly rate for all active resources in the team.\n\n---\n\nRequires team role: any",
+				"operationId": "getTeamBalanceReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Team balance information",
+						"schema": {
+							"$ref": "#/definitions/BalanceInfo"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Get team balance information",
+				"tags": ["teams"],
+				"x-requires-permissions": "team role: any"
+			}
+		},
+		"/teams/{team}/bare_metal/": {
+			"get": {
+				"description": "Returns a list of bare metal servers associated with the team.\n\n---\n\nRequires team role: any",
+				"operationId": "getBaremetalServersReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "List of bare metal servers with detailed specifications",
+						"schema": {
+							"items": {
+								"$ref": "#/definitions/BareMetalServerDetails"
+							},
+							"type": "array"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Get bare metal servers",
+				"tags": ["bare_metal"],
+				"x-requires-permissions": "team role: any"
+			},
+			"post": {
+				"description": "Reserves a bare metal server for the team, including validation of tenant limits and balance, and submits 8-hour minimum usage to Stripe.\n\n---\n\nRequires team role: operator",
+				"operationId": "reserveBaremetalServerReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"in": "body",
+						"name": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/BareMetalServerReservation"
+						}
+					}
+				],
+				"responses": {
+					"201": {
+						"description": "Server reserved successfully",
+						"schema": {
+							"$ref": "#/definitions/BareMetalServerReservationResponse"
+						}
+					},
+					"400": {
+						"description": "Bad request - invalid specifications or insufficient resources"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"402": {
+						"description": "Payment required - insufficient balance"
+					},
+					"403": {
+						"description": "Forbidden - tenant limit exceeded or insufficient permissions"
+					},
+					"404": {
+						"description": "Not found - no available servers matching specifications"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Reserve a bare metal server",
+				"tags": ["bare_metal"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/teams/{team}/bare_metal/available/": {
+			"get": {
+				"description": "Returns a list of available bare metal server types that can be reserved, including pricing information.\n\n---\n\nRequires team role: any",
+				"operationId": "getAvailableBaremetalServersReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "List of available bare metal server types with specifications and pricing",
+						"schema": {
+							"items": {
+								"$ref": "#/definitions/AvailableBareMetalTypes"
+							},
+							"type": "array"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Get available bare metal server types",
+				"tags": ["bare_metal"],
+				"x-requires-permissions": "team role: any"
+			}
+		},
+		"/teams/{team}/bare_metal/{server}/": {
+			"delete": {
+				"description": "Releases a bare metal server back to the available pool.\nWhen using force=true, the server can be released even if the minimum reservation time has not been met. However, the minimum charge for the reservation period will NOT be refunded.\n\n\n---\n\nRequires team role: operator",
+				"operationId": "deleteBaremetalServerReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Server name",
+						"in": "path",
+						"name": "server",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Force release even if minimum reservation time not met (minimum charge will not be refunded)",
+						"in": "query",
+						"name": "force",
+						"type": "boolean"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "Server released successfully"
+					},
+					"400": {
+						"description": "Bad request - server cannot be released due to minimum usage requirement"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden - insufficient permissions"
+					},
+					"404": {
+						"description": "Not found - server not found or not assigned to team"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Release a bare metal server",
+				"tags": ["bare_metal"],
+				"x-requires-permissions": "team role: operator"
+			},
+			"get": {
+				"description": "Returns detailed information about a specific bare metal server.\n\n---\n\nRequires team role: any",
+				"operationId": "getBaremetalServerReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Server name",
+						"in": "path",
+						"name": "server",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Detailed server specifications",
+						"schema": {
+							"$ref": "#/definitions/BareMetalServerDetails"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Get bare metal server details",
+				"tags": ["bare_metal"],
+				"x-requires-permissions": "team role: any"
+			},
+			"patch": {
+				"description": "Updates a bare metal server's description.\n\n---\n\nRequires team role: operator",
+				"operationId": "updateBaremetalServerReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Server name",
+						"in": "path",
+						"name": "server",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"in": "body",
+						"name": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/BareMetalServerUpdate"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "Server updated successfully"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Update a bare metal server",
+				"tags": ["bare_metal"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/teams/{team}/bare_metal/{server}/console/": {
+			"post": {
+				"description": "Returns a one time use URL for local console access\n\n---\n\nRequires team role: operator",
+				"operationId": "getBaremetalConsoleReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Server name",
+						"in": "path",
+						"name": "server",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Current power state",
+						"schema": {
+							"$ref": "#/definitions/BareMetalServerConsoleURL"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Generate URL for bare metal console access",
+				"tags": ["bare_metal"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/teams/{team}/bare_metal/{server}/power/": {
+			"get": {
+				"description": "Returns the current power state of the server.\n\n---\n\nRequires team role: any",
+				"operationId": "getServerPowerReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Server name",
+						"in": "path",
+						"name": "server",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Current power state",
+						"schema": {
+							"$ref": "#/definitions/BareMetalServerPowerState"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Get server power state",
+				"tags": ["bare_metal"],
+				"x-requires-permissions": "team role: any"
+			}
+		},
+		"/teams/{team}/bare_metal/{server}/power/ac_reset/": {
+			"post": {
+				"description": "Performs a complete AC reset of the server. The server must already be in the off state for this to succeed. BMC will also reset during an AC reset, so getting the power state or any other BMC operations will fail for several minutes while this is in progress.\n\n\n---\n\nRequires team role: operator",
+				"operationId": "serverACResetReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Server name",
+						"in": "path",
+						"name": "server",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "AC reset request successful"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Perform AC power reset",
+				"tags": ["bare_metal"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/teams/{team}/bare_metal/{server}/power/cold_reboot/": {
+			"post": {
+				"description": "Turns off and then reboots the system.\n\n---\n\nRequires team role: operator",
+				"operationId": "serverColdRebootReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Server name",
+						"in": "path",
+						"name": "server",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "Cold reboot request successful"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Cold reboot the server",
+				"tags": ["bare_metal"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/teams/{team}/bare_metal/{server}/power/force_shutdown/": {
+			"post": {
+				"description": "Immediately powers off the server without a clean shutdown. May cause data loss.\n\n---\n\nRequires team role: operator",
+				"operationId": "serverForceShutdownReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Server name",
+						"in": "path",
+						"name": "server",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "Force shutdown request successful"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Force shut down the server",
+				"tags": ["bare_metal"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/teams/{team}/bare_metal/{server}/power/graceful_shutdown/": {
+			"post": {
+				"description": "Sends an ACPI signal to the OS to initiate a clean shutdown.\n\n---\n\nRequires team role: operator",
+				"operationId": "serverGracefulShutdownReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Server name",
+						"in": "path",
+						"name": "server",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "Graceful shutdown request successful"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Gracefully shut down the server",
+				"tags": ["bare_metal"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/teams/{team}/bare_metal/{server}/power/power_on/": {
+			"post": {
+				"description": "Turns on the server if it is currently off.\n\n---\n\nRequires team role: operator",
+				"operationId": "serverPowerOnReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Server name",
+						"in": "path",
+						"name": "server",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "Power on request successful"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Power on the server",
+				"tags": ["bare_metal"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/teams/{team}/bare_metal/{server}/power/warm_reboot/": {
+			"post": {
+				"description": "Reboots the system without turning the power off completely.\n\n---\n\nRequires team role: operator",
+				"operationId": "serverWarmRebootReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Server name",
+						"in": "path",
+						"name": "server",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "Warm reboot request successful"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Warm reboot the server",
+				"tags": ["bare_metal"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/teams/{team}/bare_metal/{server}/reinstall/": {
+			"post": {
+				"description": "Resets BIOS settings, wipes all disks, and reinstalls the operating system. The reinstall process goes through several stages which can be monitored via the server details endpoint.\n1. A graceful shutdown of the server will be triggered and the status will be updated to `shutting_down`. If the server takes more than 5 minutes to shut down, a force shutdown will occur.\n2. The server will perform a full ac reset and put the server in the `ac_reset` state. This will take several minutes.\n3. When the server comes back, a reset of bios settings will be triggred and the server will be in `bios_reset` state. This will take several minutes.\n4. After the bios reset is complete, the server will boot into the installer environment and will be in the `booting_installer` state.\n5. When the installation starts the server will be in the `installing_os` state.\n6. Once the base install is complete, the server will install additional packges and will be in the `finalizing_os` state.\n7. When it completes these tasks and reboots from the installer environment the server will be in the `first_boot` state.\n8. Upon first boot, some final taks will run and the server will be in the `first_boot_tasks` state.\nIf everything completes successfully the server will be in the `installed` state.\nIf any action fails, the server will be in the `failed` state.\nThe `last_imaging_update` will indicate the timestamp of the last update to the install progress.\n\n\n---\n\nRequires team role: operator",
+				"operationId": "serverReinstallReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Server name",
+						"in": "path",
+						"name": "server",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Reinstall process initiated successfully",
+						"schema": {
+							"$ref": "#/definitions/BareMetalServerDetails"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Reinstall server OS",
+				"tags": ["bare_metal"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/teams/{team}/bare_metal/{server}/support_access_enable/": {
+			"delete": {
+				"description": "Revokes Hot Aisle support staff access to this server.\n\n---\n\nRequires team role: operator",
+				"operationId": "disableSupportAccessReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Server name",
+						"in": "path",
+						"name": "server",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "Support access disabled successfully"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Disable support access",
+				"tags": ["bare_metal"],
+				"x-requires-permissions": "team role: operator"
+			},
+			"put": {
+				"description": "Enables Hot Aisle support staff to access this server for troubleshooting.\n\n---\n\nRequires team role: operator",
+				"operationId": "enableSupportAccessReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Server name",
+						"in": "path",
+						"name": "server",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "Support access enabled successfully"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Enable support access",
+				"tags": ["bare_metal"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/teams/{team}/members/invitations/": {
+			"get": {
+				"description": "Returns a list of pending invitations for a team.\n\n---\n\nRequires team role: any",
+				"operationId": "getTeamInvitationsReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "List of team pending invitations",
+						"schema": {
+							"items": {
+								"$ref": "#/definitions/TeamMember"
+							},
+							"type": "array"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Get team's pending invitations",
+				"tags": ["teams"],
+				"x-requires-permissions": "team role: any"
+			},
+			"post": {
+				"description": "Creates an invitation for a user to join a team.\n\n---\n\nRequires team role: owner",
+				"operationId": "createTeamInvitationReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"in": "body",
+						"name": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/TeamInvitationRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "Invitation created successfully"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Invite a user to join the team",
+				"tags": ["teams"],
+				"x-requires-permissions": "team role: owner"
+			}
+		},
+		"/teams/{team}/members/{email}/": {
+			"delete": {
+				"description": "Removes a member from a team. This can be: 1. Yourself (must be a contact owner) 2. Another member (must be a team owner) 3. A pending invitation (works as rejection)\n\n\n---\n\nRequires team role: owner (to delete another member) OR user role: owner (to delete self)",
+				"operationId": "removeTeamMemberReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Email address of the team member to remove",
+						"in": "path",
+						"name": "email",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "Team member removed successfully"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Remove a member from a team",
+				"tags": ["teams"],
+				"x-requires-permissions": "team role: owner (to delete another member) OR user role: owner (to delete self)"
+			},
+			"patch": {
+				"description": "Updates a team member's roles.\n\n---\n\nRequires team role: owner",
+				"operationId": "updateTeamMemberReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Email address of the team member to update",
+						"in": "path",
+						"name": "email",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"in": "body",
+						"name": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/TeamMemberUpdate"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Team details",
+						"schema": {
+							"$ref": "#/definitions/TeamMember"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Update team member roles",
+				"tags": ["teams"],
+				"x-requires-permissions": "team role: owner"
+			}
+		},
+		"/teams/{team}/purchase-credits/": {
+			"post": {
+				"description": "Creates a Stripe checkout session for purchasing credits for the team",
+				"operationId": "purchaseTeamCredits",
+				"parameters": [
+					{
+						"description": "Team slug",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Purchase details",
+						"in": "body",
+						"name": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/PurchaseTeamCreditsRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Successful operation",
+						"schema": {
+							"$ref": "#/definitions/PurchaseTeamCreditsResponse"
+						}
+					},
+					"202": {
+						"description": "Self-Service payment approval requested"
+					},
+					"400": {
+						"description": "Invalid request"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden - user does not have purchaser role"
+					},
+					"404": {
+						"description": "Team not found"
+					},
+					"500": {
+						"description": "Internal server error"
+					}
+				},
+				"summary": "Purchase credits for a team",
+				"tags": ["teams"]
+			}
+		},
+		"/teams/{team}/virtual_machines/": {
+			"get": {
+				"description": "Returns a list of virtual machines associated with the team.\n\n---\n\nRequires team role: any",
+				"operationId": "getVirtualMachinesReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "List of virtual machines with detailed specifications",
+						"schema": {
+							"items": {
+								"$ref": "#/definitions/VirtualMachineDetails"
+							},
+							"type": "array"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Get virtual machines",
+				"tags": ["virtual_machines"],
+				"x-requires-permissions": "team role: any"
+			},
+			"post": {
+				"description": "Assigns and provisions an available virtual machine matching the specified requirements.\nOptionally provide a user_data_url to apply custom cloud-init configuration during provisioning. When provided, the VM will be assigned and then rebuilt with custom user-data applied. Default configuration will be applied as vendor-data and custom user-data will be merged.\nWARNING: Providing custom user-data will significantly increase provisioning time as the VM needs to be rebuilt. The provisioning will continue in the background if the HTTP request is canceled, but the VM will still be provisioned successfully.\n\n\n---\n\nRequires team role: operator",
+				"operationId": "assignAvailableVirtualMachineReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"in": "body",
+						"name": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/VMProvisionRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Successfully provisioned virtual machine",
+						"schema": {
+							"$ref": "#/definitions/VirtualMachineDetails"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"description": "Maximum VMs already provisioned for this team"
+					},
+					"402": {
+						"description": "Insufficient balance to provision virtual machine"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"description": "No available virtual machine matching requested specifications"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Provision a virtual machine",
+				"tags": ["virtual_machines"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/teams/{team}/virtual_machines/available/": {
+			"get": {
+				"description": "Returns a list of available virtual machine types that can be provisioned, including pricing information.\n\n---\n\nRequires team role: any",
+				"operationId": "getAvailableVirtualMachinesReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "List of available virtual machine types with specifications and pricing",
+						"schema": {
+							"items": {
+								"$ref": "#/definitions/AvailableVirtualMachineTypes"
+							},
+							"type": "array"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Get available virtual machine types",
+				"tags": ["virtual_machines"],
+				"x-requires-permissions": "team role: any"
+			}
+		},
+		"/teams/{team}/virtual_machines/{vm}/": {
+			"delete": {
+				"description": "Completely deletes a virtual machine and all its resources.\nWARNING: This operation will DELETE the VM and ALL of its data. This operation cannot be undone.\nThis request will not return until the reset is complete, but the reset will continue if the request is canceled.\nWhen using force=true, the VM can be deleted even if the minimum reservation time has not been met. However, the minimum charge for the reservation period will NOT be refunded.\n\n\n---\n\nRequires team role: operator",
+				"operationId": "deleteVMReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Virtual machine name",
+						"in": "path",
+						"name": "vm",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Force delete even if minimum reservation time not met (minimum charge will not be refunded)",
+						"in": "query",
+						"name": "force",
+						"type": "boolean"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "VM deletion was successful"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Delete a virtual machine",
+				"tags": ["virtual_machines"],
+				"x-requires-permissions": "team role: operator"
+			},
+			"get": {
+				"description": "Returns detailed information about a specific virtual machine.\n\n---\n\nRequires team role: any",
+				"operationId": "getVirtualMachineReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Virtual machine name",
+						"in": "path",
+						"name": "vm",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Detailed virtual machine specifications",
+						"schema": {
+							"$ref": "#/definitions/VirtualMachineDetails"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Get virtual machine details",
+				"tags": ["virtual_machines"],
+				"x-requires-permissions": "team role: any"
+			},
+			"patch": {
+				"description": "Updates a vrutal machine's description.\n\n---\n\nRequires team role: operator",
+				"operationId": "updateVirtualMachineReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Virtual machine name",
+						"in": "path",
+						"name": "vm",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"in": "body",
+						"name": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/VirtualMachineUpdate"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "Server updated successfully"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Update a virtual machine",
+				"tags": ["virtual_machines"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/teams/{team}/virtual_machines/{vm}/console/": {
+			"get": {
+				"description": "Opens a WebSocket connection to the virtual machine's console\n\n---\n\nRequires team role: operator",
+				"operationId": "getVMConsoleReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Virtual machine name",
+						"in": "path",
+						"name": "vm",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"101": {
+						"description": "WebSocket connection established",
+						"schema": {
+							"format": "binary",
+							"type": "string"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Connect to virtual machine console",
+				"tags": ["virtual_machines"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/teams/{team}/virtual_machines/{vm}/hard-reset/": {
+			"post": {
+				"description": "Forcefully resets a running virtual machine (equivalent to pressing the hardware reset button). This operation is abrupt and may result in data loss if the VM's filesystem is not properly synced. Use the graceful reboot endpoint when possible.\n\n\n---\n\nRequires team role: operator",
+				"operationId": "hardResetVMReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Virtual machine name",
+						"in": "path",
+						"name": "vm",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "VM hard reset operation was successful"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Forcefully reset a virtual machine",
+				"tags": ["virtual_machines"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/teams/{team}/virtual_machines/{vm}/reboot/": {
+			"post": {
+				"description": "Gracefully reboots a running virtual machine by sending an ACPI reboot signal. This allows the guest OS to perform a clean shutdown and restart. This is the preferred way to restart a VM when possible.\n\n\n---\n\nRequires team role: operator",
+				"operationId": "rebootVMReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Virtual machine name",
+						"in": "path",
+						"name": "vm",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "VM reboot operation was successful"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Gracefully reboot a virtual machine",
+				"tags": ["virtual_machines"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/teams/{team}/virtual_machines/{vm}/rebuild/": {
+			"post": {
+				"description": "Performs a complete rebuild of the virtual machine to its initial state.\nWARNING: This operation will DELETE ALL DATA on the virtual machine. The VM will be recreated from the original template, resulting in complete data loss. This operation cannot be undone.\nOptionally provide a user_data_url to apply custom cloud-init configuration during the rebuild. When provided, default configuration will be applied as vendor-data and custom user-data will be merged.\nThis request will not return until the rebuild is complete, but the rebuild will continue if the request is canceled.\n\n\n---\n\nRequires team role: operator",
+				"operationId": "rebuildVMReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Virtual machine name",
+						"in": "path",
+						"name": "vm",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"in": "body",
+						"name": "body",
+						"schema": {
+							"$ref": "#/definitions/VMResetRequest"
+						}
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "VM rebuild operation was successful"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Rebuild a virtual machine in its initial state",
+				"tags": ["virtual_machines"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/teams/{team}/virtual_machines/{vm}/shutdown/": {
+			"post": {
+				"description": "Sends a graceful shutdown signal to a running virtual machine.\n\n---\n\nRequires team role: operator",
+				"operationId": "shutdownVMReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Virtual machine name",
+						"in": "path",
+						"name": "vm",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "VM shutdown operation was successful"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Gracefully shutdown a virtual machine",
+				"tags": ["virtual_machines"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/teams/{team}/virtual_machines/{vm}/start/": {
+			"post": {
+				"description": "Starts a virtual machine that is currently stopped.\n\n---\n\nRequires team role: operator",
+				"operationId": "startVMReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Virtual machine name",
+						"in": "path",
+						"name": "vm",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "VM start operation was successful"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Start a virtual machine",
+				"tags": ["virtual_machines"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/teams/{team}/virtual_machines/{vm}/state/": {
+			"get": {
+				"description": "Returns the current power state of the virtual machine.\n\n---\n\nRequires team role: any",
+				"operationId": "getVMStateReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Virtual machine name",
+						"in": "path",
+						"name": "vm",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Current virtual machine state",
+						"schema": {
+							"$ref": "#/definitions/VirtualMachineState"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Get virtual machine state",
+				"tags": ["virtual_machines"],
+				"x-requires-permissions": "team role: any"
+			}
+		},
+		"/teams/{team}/virtual_machines/{vm}/stop/": {
+			"post": {
+				"description": "Forcefully stops a running virtual machine (equivalent to pulling the power).\n\n---\n\nRequires team role: operator",
+				"operationId": "stopVMReq",
+				"parameters": [
+					{
+						"description": "Team handle",
+						"in": "path",
+						"name": "team",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"description": "Virtual machine name",
+						"in": "path",
+						"name": "vm",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "VM stop operation was successful"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Forcefully stop a virtual machine",
+				"tags": ["virtual_machines"],
+				"x-requires-permissions": "team role: operator"
+			}
+		},
+		"/user/": {
+			"get": {
+				"description": "Returns user details including name, email, and account creation date for the authenticated user. Also includes information about the teams the user belongs to, including roles.\n\n\n---\n\nRequires user role: any",
+				"operationId": "getUserReq",
+				"responses": {
+					"200": {
+						"description": "User information with teams",
+						"schema": {
+							"$ref": "#/definitions/GetUserResponse"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Get information about the currently authenticated user.",
+				"tags": ["user"],
+				"x-requires-permissions": "user role: any"
+			},
+			"patch": {
+				"description": "Allows updating user profile information such as display name.\n\n\n---\n\nRequires user role: owner",
+				"operationId": "updateUserReq",
+				"parameters": [
+					{
+						"in": "body",
+						"name": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/UserUpdate"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "Updated user profile",
+						"schema": {
+							"$ref": "#/definitions/User"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Update the currently authenticated user profile.",
+				"tags": ["user"],
+				"x-requires-permissions": "user role: owner"
+			}
+		},
+		"/user/api_keys/": {
+			"get": {
+				"description": "Returns a list of all API keys belonging to the user.\n\n---\n\nRequires user role: any",
+				"operationId": "getUserAPIKeysReq",
+				"responses": {
+					"200": {
+						"description": "List of API keys",
+						"schema": {
+							"items": {
+								"$ref": "#/definitions/UserAPIKey"
+							},
+							"type": "array"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Get user API keys",
+				"tags": ["user"],
+				"x-requires-permissions": "user role: any"
+			},
+			"post": {
+				"description": "Creates a new API key with specified permissions.\n\n---\n\nRequires user role: owner",
+				"operationId": "createAPIKeyReq",
+				"parameters": [
+					{
+						"in": "body",
+						"name": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/UserAPIKeyRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "API key created successfully, returns key details including one-time token",
+						"schema": {
+							"$ref": "#/definitions/UserAPIKeyWithToken"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Create a new API key",
+				"tags": ["user"],
+				"x-requires-permissions": "user role: owner"
+			}
+		},
+		"/user/api_keys/{prefix}/": {
+			"delete": {
+				"description": "Permanently deletes an API key.\n\n---\n\nRequires user role: owner",
+				"operationId": "deleteAPIKeyReq",
+				"parameters": [
+					{
+						"description": "API key prefix identifier",
+						"in": "path",
+						"name": "prefix",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "API key successfully deleted"
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Delete an API key",
+				"tags": ["user"],
+				"x-requires-permissions": "user role: owner"
+			},
+			"get": {
+				"description": "Returns detailed information about a specific API key.\n\n---\n\nRequires user role: any",
+				"operationId": "getUserAPIKeyDetailReq",
+				"parameters": [
+					{
+						"description": "API key prefix identifier",
+						"in": "path",
+						"name": "prefix",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "API key details",
+						"schema": {
+							"$ref": "#/definitions/UserAPIKey"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Get specific API key details",
+				"tags": ["user"],
+				"x-requires-permissions": "user role: any"
+			},
+			"patch": {
+				"description": "Updates an existing API key with new permissions or label.\n\n---\n\nRequires user role: owner",
+				"operationId": "updateAPIKeyReq",
+				"parameters": [
+					{
+						"description": "API key prefix identifier",
+						"in": "path",
+						"name": "prefix",
+						"required": true,
+						"type": "string"
+					},
+					{
+						"in": "body",
+						"name": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/UserAPIKeyRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "API key updated successfully",
+						"schema": {
+							"$ref": "#/definitions/UserAPIKey"
+						}
+					},
+					"400": {
+						"$ref": "#/responses/BadRequest"
+					},
+					"401": {
+						"$ref": "#/responses/Unauthorized"
+					},
+					"403": {
+						"$ref": "#/responses/Forbidden"
+					},
+					"404": {
+						"$ref": "#/responses/NotFound"
+					},
+					"422": {
+						"$ref": "#/responses/UnprocessableEntity"
+					},
+					"500": {
+						"$ref": "#/responses/InternalError"
+					}
+				},
+				"summary": "Update an API key",
+				"tags": ["user"],
+				"x-requires-permissions": "user role: owner"
+			}
+		},
+		"/user/ssh_keys/": {
+			"get": {
+				"description": "Returns a list of all SSH keys belonging to the user.\n\n---\n\nRequires user role: any",
+				"operationId": "getUserSSHKeysReq",
+				"responses": {
+					"200": {
+						"description": "List of SSH keys",
+						"schema": {
+							"items": {
+								"$ref": "#/definitions/SSHKey"
+							},
+							"type": "array"
+						}
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				},
+				"summary": "Get user SSH keys",
+				"tags": ["user", "ssh"],
+				"x-requires-permissions": "user role: any"
+			},
+			"post": {
+				"description": "Adds a new SSH public key to the user's account.\n\n---\n\nRequires user role: owner",
+				"operationId": "addSSHKeyReq",
+				"parameters": [
+					{
+						"in": "body",
+						"name": "body",
+						"required": true,
+						"schema": {
+							"$ref": "#/definitions/SSHKeyRequest"
+						}
+					}
+				],
+				"responses": {
+					"200": {
+						"description": "SSH key added successfully",
+						"schema": {
+							"$ref": "#/definitions/SSHKey"
+						}
+					},
+					"400": {
+						"description": "Bad request - invalid input"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden - not a contact owner"
+					},
+					"409": {
+						"description": "Conflict - key already registered"
+					},
+					"422": {
+						"description": "Unprocessable Entity - invalid SSH key format"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				},
+				"summary": "Add a new SSH key",
+				"tags": ["user", "ssh"],
+				"x-requires-permissions": "user role: owner"
+			}
+		},
+		"/user/ssh_keys/{fingerprint}/": {
+			"delete": {
+				"description": "Permanently deletes an SSH key from the user's account.\n\n---\n\nRequires user role: owner",
+				"operationId": "deleteSSHKeyReq",
+				"parameters": [
+					{
+						"description": "SSH key fingerprint value (the part after \"SHA256:\" in the full fingerprint)",
+						"in": "path",
+						"name": "fingerprint",
+						"required": true,
+						"type": "string"
+					}
+				],
+				"responses": {
+					"204": {
+						"description": "SSH key successfully deleted"
+					},
+					"401": {
+						"description": "Unauthorized"
+					},
+					"403": {
+						"description": "Forbidden - not a contact owner"
+					},
+					"404": {
+						"description": "SSH key not found"
+					},
+					"500": {
+						"description": "Internal Server Error"
+					}
+				},
+				"summary": "Delete an SSH key",
+				"tags": ["user", "ssh"],
+				"x-requires-permissions": "user role: owner"
+			}
+		}
+	},
+	"produces": ["application/json"],
+	"responses": {
+		"BadRequest": {
+			"description": "Invalid request format or parameters",
+			"schema": {
+				"example": "Bad Request: Invalid input",
+				"type": "string"
+			}
+		},
+		"Error": {
+			"description": "Error response",
+			"schema": {
+				"example": "Error message",
+				"type": "string"
+			}
+		},
+		"Forbidden": {
+			"description": "Permission denied - the authenticated user doesn't have required permissions",
+			"schema": {
+				"example": "Forbidden: Permission denied",
+				"type": "string"
+			}
+		},
+		"InternalError": {
+			"description": "An unexpected error occurred on the server",
+			"schema": {
+				"example": "Internal Server Error",
+				"type": "string"
+			}
+		},
+		"NotFound": {
+			"description": "The requested resource was not found",
+			"schema": {
+				"example": "Not Found: Resource not found",
+				"type": "string"
+			}
+		},
+		"Unauthorized": {
+			"description": "Authentication information is missing or invalid",
+			"schema": {
+				"example": "Unauthorized",
+				"type": "string"
+			}
+		},
+		"UnprocessableEntity": {
+			"description": "Validation failed - request parameters are invalid",
+			"schema": {
+				"example": "Unprocessable Entity: Invalid data format",
+				"type": "string"
+			}
+		}
+	},
+	"security": [
+		{
+			"token": []
+		}
+	],
+	"securityDefinitions": {
+		"token": {
+			"description": "Please enter in the word 'Token', a space, and then paste in your token.",
+			"in": "header",
+			"name": "Authorization",
+			"type": "apiKey"
+		}
+	},
+	"swagger": "2.0",
+	"tags": [
+		{
+			"name": "user"
+		},
+		{
+			"description": "Manage ssh key access to your servers.\n\nSSH Access is provided by the configuration in `/etc/ssh/sshd_config.d/70-hotaisle-auth-keys.conf` which dynamically fetches ssh keys from this API for your server on login. If the live fetch succeeds, those keys are used immediately. It also keeps a best-effort cache in `~/.ssh/hotaisle_managed_keys` and falls back to that cache if the live fetch fails.\n\nIf you want to disable automatic key management, simply delete `/etc/ssh/sshd_config.d/70-hotaisle-auth-keys.conf`.\n\nSSH Keys associated with any member of a team with the `user` role will be permitted to login as the `hotaisle` user on a server.\n\nAdditionally if `support_access_enabled` is true, Hot Aisle support will also have access to the server.\n\nAutomatic key management does not touch the `~/.ssh/authorized_keys` file, so any changes you make there will not be reflected here. Additionally automatic key management does not affect any users except the `hotaisle` user.\n",
+			"name": "ssh"
+		},
+		{
+			"name": "teams"
+		},
+		{
+			"name": "bare_metal"
+		},
+		{
+			"name": "virtual_machines"
+		},
+		{
+			"name": "deprecated"
+		}
+	]
 }


### PR DESCRIPTION
## Summary

- Update `swagger.json` to the latest API schema and add the new balance count fields to the Go client model.
- Require `gpu-count` when provisioning virtual machines and clarify VM billing behavior in command help text.
- Bump the project Go version to 1.26.4 and refresh Go dependencies.
- Update GitHub Actions pins for checkout, cache, and setup-just.

## Impact

The CLI client now matches the latest API balance response shape, VM provisioning exposes the required GPU count option, and CI/release automation uses current action versions.

## Validation

- `go test ./...`