### PR TITLE
docs: update apt repo key filename

### DIFF
--- a/APT_REPO_SETUP.md
+++ b/APT_REPO_SETUP.md
@@ -87,8 +87,8 @@ Your APT repository will be available at: `https://hotaisle.github.io/apt-repo`
 
 ```bash
 cd apt-repo
-cp public.key hotaisle-archive-keyring.gpg
-git add hotaisle-archive-keyring.gpg
+cp public.key gpg.key
+git add gpg.key
 git commit -m "Add public GPG key"
 git push origin main
 ```
@@ -105,10 +105,10 @@ Create a file `/etc/apt/sources.list.d/hotaisle.list`:
 
 ```bash
 # Add repository
-echo "deb [signed-by=/usr/share/keyrings/hotaisle-archive-keyring.gpg] https://hotaisle.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/hotaisle.list
+echo "deb [signed-by=/usr/share/keyrings/hotaisle-gpg.key] https://hotaisle.github.io/apt-repo stable main" | sudo tee /etc/apt/sources.list.d/hotaisle.list
 
 # Add GPG key
-curl -fsSL https://hotaisle.github.io/apt-repo/hotaisle-archive-keyring.gpg | sudo tee /usr/share/keyrings/hotaisle-archive-keyring.gpg > /dev/null
+curl -fsSL https://hotaisle.github.io/apt-repo/gpg.key | sudo tee /usr/share/keyrings/hotaisle-gpg.key > /dev/null
 
 # Update and install
 sudo apt update

--- a/justfile
+++ b/justfile
@@ -81,7 +81,8 @@ go_version := shell(go + ' version')
 version := `git describe --tags --match 'v*' 2>/dev/null || echo "dev"`
 
 git_commit := trim(`git rev-parse --short HEAD 2>/dev/null || echo "unknown"`)
-git_branch := trim(shell('git rev-parse --abbrev-ref HEAD 2>/dev/null || echo ""')) || "unknown"
+git_branch_raw := trim(shell('git rev-parse --abbrev-ref HEAD 2>/dev/null || echo ""'))
+git_branch := if git_branch_raw == "" { "unknown" } else { git_branch_raw }
 build_time := `date -u '+%Y-%m-%d_%H:%M:%S'`
 build_by := `whoami`
 
@@ -372,4 +373,3 @@ version:
 	@echo "Build by:    {{build_by}}"
 	@echo "Build time:  {{build_time}}"
 	@echo "Go version:  {{go_version}}"
-


### PR DESCRIPTION
## Summary
- update APT repository setup instructions to publish the public key as gpg.key
- update installation instructions to fetch gpg.key from the APT repository

## Tests
- not run; documentation-only change